### PR TITLE
Fix short php tags.

### DIFF
--- a/lib/lms_lib.php
+++ b/lib/lms_lib.php
@@ -1680,7 +1680,7 @@ class default_renderer {
               </ul>
             </div><!--/.nav-collapse -->
           </div>
-    <?
+    <?php
     }
 }
 


### PR DESCRIPTION
I was getting an error because by default Ubuntu doesn't have short tags enabled for php5.

[Tue Jun 03 18:21:44.675414 2014] [:error] [pid 5444] [client 127.0.0.1:40289] PHP Parse error:  syntax error, unexpected end of file in /var/www/html/tsugi/lib/lms_lib.php on line 1692
