### PR TITLE
DEV.php update to persist user key

### DIFF
--- a/dev.php
+++ b/dev.php
@@ -104,6 +104,7 @@ if ( isset($_POST['instructor']) ) {
 }
 
 // Set up default LTI data
+$key = isset($_REQUEST['key']) ? trim($_REQUEST["key"]) : $key; // UPDATE FORM JOSH HARINGTON TO PERSIST USER DEFINED KEY
 $secret = isset($_REQUEST["secret"]) ? trim($_REQUEST["secret"]) : "secret";
 $endpoint = isset($_REQUEST["endpoint"]) ? trim($_REQUEST["endpoint"]) : false;
 if ( $endpoint == 'false' ) $endpoint = false;


### PR DESCRIPTION
What was happening was that all of my attempts at using keys other than `12345` would default back to `12345`. After inspection of `dev.php` I saw that tsugi was not updating the `$key` variable from `12345` to the what the user passed in in the `$_REQUEST`. So after making this change, tsugi worked with my LTI components that needed specific keys / secrets.

Thanks,
Josh Harington