### PR TITLE
fixed possible bug in creating lti_domain DB table updated_at

### DIFF
--- a/admin/lti/database.php
+++ b/admin/lti/database.php
@@ -391,7 +391,7 @@ array( "{$CFG->dbprefix}lti_domain",
     secret      TEXT,
     json        TEXT NULL,
     created_at  TIMESTAMP NOT NULL,
-    updated_at  TIMESTAMP NOT NULL,
+    updated_at  TIMESTAMP NOT NULL DEFAULT '1970-01-02 00:00:00',
 
     CONSTRAINT `{$CFG->dbprefix}lti_domain_ibfk_1`
         FOREIGN KEY (`key_id`)


### PR DESCRIPTION
My AWS Lightsail/Bitnami hosting borked on the db upgrade here and this fixed it. Not sure if it's a bug or not, but thought I'd pass it along and see.