### PR TITLE
note about symbolically linking the config.php file

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -16,7 +16,8 @@ $wwwroot = "http://localhost/tsugi";
 // $apphome = "https://www.tsugi.org";
 // $wwwroot = $apphome . '/tsugi';
 // Make sure to check for all the "Embedded Tsugi" configuration options below
-
+// If this file is symbolically linked you'll need to manually define the absolute path,
+// otherwise this will resolve correctly.
 $dirroot = realpath(dirname(__FILE__));
 
 $loader = require_once($dirroot."/vendor/autoload.php");


### PR DESCRIPTION
If config.php is symlinked instead of directly included in the local directory it's self-discovery default function for $dirroot will resolve incorrectly causing a 500 error. This adds a simple comment noting this.