### PR TITLE
Sample for the config-dist file to help w/ deep level 500 errors

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -1,5 +1,12 @@
 <?php
-
+// uncomment for 500 error debugging during early install steps
+/*
+function __the_end(){
+    if(($err=error_get_last()))
+        die('<pre>'.print_r($err,true).'</pre>');
+}
+register_shutdown_function('__the_end');
+*/
 // Configuration file - copy from config-dist.php to config.php
 // and then edit.  Since config.php has passwords and other secrets
 // never check config.php into a source repository


### PR DESCRIPTION
Provides an example debug function which has proven critical in other PHP projects I've written / used in order to debug initial install / deep level admin areas which can throw difficult to debug 500 errors otherwise. This forces the buffer to return a response as to what the error was. Either placing it in this file as an example of throwing it into the documentation might be helpful long term.