### PR TITLE
Added access to the json column class user (lti_user)

### DIFF
--- a/vendor/tsugi/lib/src/Core/Entity.php
+++ b/vendor/tsugi/lib/src/Core/Entity.php
@@ -2,7 +2,6 @@
 
 namespace Tsugi\Core;
 
-use \Tsugi\Util\U;
 use \Tsugi\Core\LTIX;
 
 /**
@@ -27,76 +26,6 @@ class Entity {
     // Pull in all the session access functions
     use SessionTrait;
 
-    /**
-     * Load the json field for this entity
-     *
-     * @return string This returns the json string - it is not parsed - if there is
-     * nothing to return - this returns "false"
-     */
-    public function getJson()
-    {
-        global $CFG, $PDOX;
-
-        $row = $PDOX->rowDie("SELECT json FROM {$CFG->dbprefix}{$this->TABLE_NAME}
-                WHERE $this->PRIMARY_KEY = :PK",
-            array(":PK" => $this->id));
-        if ( $row === false ) return false;
-        $json = $row['json'];
-        if ( $json === null ) return false;
-        return $json;
-    }
-
-    /**
-     * Get a JSON key for this entity
-     *
-     * @params $key The key to be retrieved from the JSON
-     * @params $default The default value (optional)
-     *
-     */
-    public function getJsonKey($key,$default=false)
-    {
-        global $CFG, $PDOX;
-
-        $jsonStr = $this->getJson();
-        if ( ! $jsonStr ) return $default;
-        $json = json_decode($jsonStr, true);
-        if ( ! $json ) return $default;
-        return U::get($json, $key, $default);
-    }
-
-    /**
-     * Set the JSON entry for this entity
-     *
-     * @params $json This is a string - no validation is done
-     *
-     */
-    public function setJson($json)
-    {
-        global $CFG, $PDOX;
-
-        $q = $PDOX->queryDie("UPDATE {$CFG->dbprefix}{$this->TABLE_NAME}
-                SET json = :SET WHERE $this->PRIMARY_KEY = :PK",
-            array(":SET" => $json, ":PK" => $this->id)
-        );
-    }
-
-    /**
-     * Set/update a JSON key for this entity
-     *
-     * @params $key The key to be inserted/updated in the JSON
-     * @params $value The value to be inserted/updated in the JSON
-     *
-     */
-    public function setJsonKey($key,$value)
-    {
-        global $CFG, $PDOX;
-
-        $old = $this->getJson();
-        $old_json = json_decode($old);
-        if ( $old_json == null ) $old_json = new \stdClass();
-        $old_json->{$key} = $value;
-        $new = json_encode($old_json);
-        $this->setJson($new);
-    }
-
+    // Pull in all the json access functions
+    use JsonTrait;
 }

--- a/vendor/tsugi/lib/src/Core/JsonTrait.php
+++ b/vendor/tsugi/lib/src/Core/JsonTrait.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tsugi\Core;
+
+use \Tsugi\Util\U;
+
+/**
+ * This is a class holding convienence methods to access the json column for the core objects.
+ * 
+ * This is a more general storage than the settings column.
+ */
+
+trait JsonTrait {
+
+    /**
+     * Load the json field for this entity
+     *
+     * @return string This returns the json string - it is not parsed - if there is
+     * nothing to return - this returns "false"
+     */
+    public function getJson()
+    {
+        global $CFG, $PDOX;
+
+        $row = $PDOX->rowDie("SELECT json FROM {$CFG->dbprefix}{$this->TABLE_NAME}
+                WHERE $this->PRIMARY_KEY = :PK",
+            array(":PK" => $this->id));
+        if ( $row === false ) return false;
+        $json = $row['json'];
+        if ( $json === null ) return false;
+        return $json;
+    }
+
+    /**
+     * Get a JSON key for this entity
+     *
+     * @params $key The key to be retrieved from the JSON
+     * @params $default The default value (optional)
+     *
+     */
+    public function getJsonKey($key,$default=false)
+    {
+        global $CFG, $PDOX;
+
+        $jsonStr = $this->getJson();
+        if ( ! $jsonStr ) return $default;
+        $json = json_decode($jsonStr, true);
+        if ( ! $json ) return $default;
+        return U::get($json, $key, $default);
+    }
+
+    /**
+     * Set the JSON entry for this entity
+     *
+     * @params $json This is a string - no validation is done
+     *
+     */
+    public function setJson($json)
+    {
+        global $CFG, $PDOX;
+
+        $q = $PDOX->queryDie("UPDATE {$CFG->dbprefix}{$this->TABLE_NAME}
+                SET json = :SET WHERE $this->PRIMARY_KEY = :PK",
+            array(":SET" => $json, ":PK" => $this->id)
+        );
+    }
+
+    /**
+     * Set/update a JSON key for this entity
+     *
+     * @params $key The key to be inserted/updated in the JSON
+     * @params $value The value to be inserted/updated in the JSON
+     *
+     */
+    public function setJsonKey($key,$value)
+    {
+        global $CFG, $PDOX;
+
+        $old = $this->getJson();
+        $old_json = json_decode($old);
+        if ( $old_json == null ) $old_json = new \stdClass();
+        $old_json->{$key} = $value;
+        $new = json_encode($old_json);
+        $this->setJson($new);
+    }
+}

--- a/vendor/tsugi/lib/src/Core/User.php
+++ b/vendor/tsugi/lib/src/Core/User.php
@@ -18,6 +18,14 @@ use \Tsugi\Core\Cache;
 
 class User {
 
+    // Needed to implement the Entity methods
+    protected $TABLE_NAME = "lti_user";
+    protected $PRIMARY_KEY = "user_id";
+
+    // Links have settings...
+    protected $ENTITY_NAME = "user";
+    use JsonTrait;  // Pull in the trait
+ 
     /**
      * The integer primary key for this user in the 'lti_user' table.
      */


### PR DESCRIPTION
Hi Chuck,

In the development of a few tools we needed a place to store a a value or two that are important to a particular user and should be cross tool usable. The other core object contain a settings column, but without changing the database this seems to be a good solution.

Yes, the value is then accessible by other (outside) tools and may even be overwritten by them 😣 

Hope this is what you had in mind for this column - more general settings/variable storage.

All the best,
Corné