### PR TITLE
option to use apache2 mod_proxy_tunnel for websocket

### DIFF
--- a/admin/rachet.php
+++ b/admin/rachet.php
@@ -81,7 +81,15 @@ class MyNotify implements MessageComponentInterface {
 }
 
 if ( WebSocket::enabled() ) {
-    $port = WebSocket::getPort();
+    
+    $proxyport = WebSocket::getProxyPort();
+
+    if ( $proxyport ) {
+        $port = $proxyport;
+    } else {
+        $port = WebSocket::getPort();
+    }
+    
     $host = WebSocket::getHost();
     $app = new Ratchet\App($host, $port, '0.0.0.0');
     $app->route('/notify', new MyNotify, array('*'));

--- a/config-dist.php
+++ b/config-dist.php
@@ -58,6 +58,11 @@ unset($apphome);
 // $CFG->websocket_url = 'ws://localhost:2021'; // Local dev test
 // $CFG->websocket_url = 'wss://socket.tsugicloud.org:443'; // Production
 
+// If you are running a reverse proxy (proxy_wstunnel) set this to the port
+// you will forward to in your apache config  
+// $CFG->websocket_proxyport = 8080;
+
+
 
 // Database connection information to configure the PDO connection
 // You need to point this at a database with am account and password

--- a/vendor/tsugi/lib/src/Core/WebSocket.php
+++ b/vendor/tsugi/lib/src/Core/WebSocket.php
@@ -107,7 +107,7 @@ class WebSocket {
      */
     public static function getProxyPort() {
         global $CFG;
-        if ( ! self::enabled() ) return null;
+        if ( ! isset($CFG->websocket_proxyport) ) return null;
         return $CFG->websocket_proxyport;
     }
 

--- a/vendor/tsugi/lib/src/Core/WebSocket.php
+++ b/vendor/tsugi/lib/src/Core/WebSocket.php
@@ -101,6 +101,15 @@ class WebSocket {
         $pieces = parse_url($CFG->websocket_url);
         return U::get($pieces,'port');
     }
+    
+    /**
+     * Returns the proxyport if set in config
+     */
+    public static function getProxyPort() {
+        global $CFG;
+        if ( ! self::enabled() ) return null;
+        return $CFG->websocket_proxyport;
+    }
 
     /**
      * Returns the host that the configured web socket server


### PR DESCRIPTION
Some folks may want to setup their websocket using proxy_wstunnel.  In such a case the rachet server may need to listen on a different port than http/https requests. 