### PR TITLE
Each() is deprecated in PHP 7.2 so replace with foreach

### DIFF
--- a/vendor/tsugi/lib/src/Util/LTI.php
+++ b/vendor/tsugi/lib/src/Util/LTI.php
@@ -722,7 +722,7 @@ class LTI {
             $result = array();
             $members = $xml->xpath('/message_response/members/member');
 
-            while(list( , $node) = each($members)) {
+            foreach($members as $node) {
                 $groups = array();
                 foreach($node->groups as $k) {
                     foreach($k->group as $v) {


### PR DESCRIPTION
If using roster feature in a tool a warning will show in the Tsugi tool that says,
"Deprecated: The each() function is deprecated. This message will be suppressed on
further calls in /.../vendor/tsugi/lib/src/Util/LTI.php on line 684"