### PR TITLE
Escape reserved word rank with backticks

### DIFF
--- a/admin/install/database.php
+++ b/admin/install/database.php
@@ -17,7 +17,7 @@ array( "{$CFG->dbprefix}lms_tools",
     git_user            VARCHAR(1024) NULL,
     git_password        VARCHAR(1024) NULL,
 
-    rank                INTEGER NULL,
+    `rank`              INTEGER NULL,
     deleted             TINYINT(1) NOT NULL DEFAULT 0,
 
     json                MEDIUMTEXT NULL,


### PR DESCRIPTION
In MySQL 8, "rank" is a reserved word and shouldn't be used as a column name.
This can still be done if you use backticks to escape the name.