### PR TITLE
Roster information stored in lti_user and lti_membership.

### DIFF
--- a/vendor/tsugi/lib/src/Core/LTIX.php
+++ b/vendor/tsugi/lib/src/Core/LTIX.php
@@ -2705,14 +2705,19 @@ class LTIX {
      * populateRoster
      *
      * If the LTI Extension: Context Memberships Service is supported in the launch, get the memberships
-     * information
+     * information and insert the information into lti_user and lti_membership
      *
      * @param bool $groups, whether or not to get groups in the Memberships
+     * @param bool $insert, whether or not to insert the members found into lti_user, lti_membership
      * @return bool true if successful, false if not possible
      */
-    public static function populateRoster($groups=false) {
-        global $ROSTER;
+    public static function populateRoster($groups=false, $insert=false) {
+        global $ROSTER, $CFG, $TSUGI_LAUNCH;
         if(!is_object($ROSTER)) {
+            return false;
+        }
+
+        if (filter_var($ROSTER->url, FILTER_VALIDATE_URL) === FALSE) {
             return false;
         }
 
@@ -2723,12 +2728,57 @@ class LTIX {
 
         if($response != false) {
             $ROSTER->data = $response;
-        }
+
+            if ($insert) {
+                $PDOX = self::getConnection();
+                $p = $CFG->dbprefix;
+
+                $errormode = $PDOX->getAttribute(\PDO::ATTR_ERRMODE);
+                $PDOX->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+                // Set up user
+                $insertUser = "INSERT INTO {$p}lti_user
+                        ( user_key, user_sha256, displayname, email, locale, json, key_id, created_at, updated_at ) VALUES ";
+
+                // Set up membership
+                $insertMembership = "INSERT INTO {$p}lti_membership
+                        ( context_id, user_id, role, created_at, updated_at ) VALUES ";
+
+                $key = $PDOX->rowDie("SELECT key_id
+                      FROM {$CFG->dbprefix}lti_key WHERE key_key = :key",
+                      array(':key' => $TSUGI_LAUNCH->context->key));
+                if (! $key ) return false;
+
+                $insertUserArray = [];
+                $insertUserMembershipArray = [];
+                foreach($ROSTER->data as $user) {
+                    array_push($insertUserArray,
+                            "('". $user['user_id'] ."', '".
+                                    lti_sha256($user['user_id']) ."', '".
+                                    $user['user_name'] ."', '".
+                                    $user['user_email'] ."', '".
+                                    ($TSUGI_LAUNCH->context->launch->user->locale ? $TSUGI_LAUNCH->context->launch->user->locale : ''). "', ".
+                                    "'{\"sourcedId\": \"". $user['lis_result_sourcedid'] ."\"}', ".
+                                    $key['key_id'] .", NOW(), NOW() )");
+
+                    array_push($insertUserMembershipArray,
+                            "(". $TSUGI_LAUNCH->context->id .", ".
+                                "(select user_id from {$p}lti_user where user_key = '". $user['user_id'] ."' limit 1), ".
+                                    ($user['role'] == "Instructor" ? LTIX::ROLE_INSTRUCTOR : LTIX::ROLE_LEARNER) .", NOW(), NOW() )");
+                }
+                $PDOX->queryDie($insertUser . implode(',', $insertUserArray)
+                            ." ON DUPLICATE KEY UPDATE "
+                                ." displayname = VALUES(displayname)"
+                                ." ,email = VALUES(email)"
+                                ." ,updated_at = NOW()"
+                                ." ,json = IF(JSON_VALID(json), JSON_SET(json, '$.sourcedId', JSON_EXTRACT(VALUES(json),'$.sourcedId')), VALUES(json))");
+                             //   ." ,json = REPLACE(CONCAT(IFNULL(json,'{}'), VALUES(json)), '}{', ',')");
+                $PDOX->queryDie($insertMembership . implode(',', $insertUserMembershipArray). " ON DUPLICATE KEY UPDATE role = VALUES(role), updated_at=NOW()");
+            } // if insert
+        } // if response valid
 
         return true;
     }
-
-
 
     public static function getBrowserSignature() {
         $concat = self::getBrowserSignatureRaw();

--- a/vendor/tsugi/lib/src/Util/LTI.php
+++ b/vendor/tsugi/lib/src/Util/LTI.php
@@ -713,7 +713,7 @@ class LTI {
     public static function parseContextMembershipsResponse($response) {
         $result = false;
         try{
-            $xml = new \SimpleXMLElement($response);
+            $xml = new \SimpleXMLElement(utf8_encode($response));
             $success = $xml->xpath("/message_response/statusinfo");
 
             if($success[0]->codemajor != "Success") {
@@ -722,7 +722,7 @@ class LTI {
             $result = array();
             $members = $xml->xpath('/message_response/members/member');
 
-            foreach($members as $node) {
+            foreach($members as $index => $node) {
                 $groups = array();
                 foreach($node->groups as $k) {
                     foreach($k->group as $v) {
@@ -737,7 +737,9 @@ class LTI {
                     "user_id" => $node->user_id->__toString(),
                     "role" => $node->role->__toString(),
                     "roles" => $node->roles->__toString(),
-                    "lis_result_sourcedid" => $node->lis_result_sourcedid->__toString(),
+                    "user_email" => $node->person_contact_email_primary->__toString(),
+                    "user_name" => $node->person_name_full->__toString(),
+                    "lis_result_sourcedid" => empty($node->lis_result_sourcedid->__toString()) ? $node->person_sourcedid->__toString() : $node->lis_result_sourcedid->__toString(),
                     "groups" => $groups
                 );
             }


### PR DESCRIPTION
So by default this doesn't change any of the standard functionality it adds the option after the page is loaded then by calling:
```
  // Handle the Roster
  $handledRoster = LTIX::populateRoster(false, true);
```
The lti_user and lti_membership tables are updated with the student roster. 
This should be a considered action because the size of the roster might be quite large and not something to do every time the page loads.

- SimpleXMLElement parse error - utf8_encode added to response function
- Valid Roster->url  before going to all the trouble of getting the membership
- populateRoster function documentation update
- Fixed how the person source id is found and how it is updated in MySQL (using json functions)
- roster insert is false by default