### PR TITLE
Update Docker to php8.1 and docker compose command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache
+FROM php:8.1-apache
 #Install git
 EXPOSE 80
 # Modules that this needs

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ your web server can read it
 
 ### Method 1: Docker install
 
-* If you have Docker installed (OSX/Linux currently) you should just be able to run `docker-compose build` and `docker-compose up` and Tsugi will start up and initialize.
+* If you have Docker installed (OSX/Linux currently) you should just be able to run `docker compose build` and `docker compose up` and Tsugi will start up and initialize.
 * config-dist.php will be copied, you need to edit a few things in this like `CFG->adminpw`just edit these in place and they'll be updated.
 * Go to http://localhost:8888/tsugi and you should be all set.
 


### PR DESCRIPTION
Looks like this had been updated recently to support PHP 8.1, so just updating the Docker to build off that. Started it up and looks like it works fine.