### PR TITLE
Fix for  Deprecated: htmlentities(): Passing null to parameter : Issue #146

### DIFF
--- a/vendor/tsugi/lib/src/Util/U.php
+++ b/vendor/tsugi/lib/src/Util/U.php
@@ -50,7 +50,7 @@ class U {
     }
 
     public static function htmlent_utf8($string) {
-        return htmlentities($string,ENT_QUOTES,$encoding = 'UTF-8');
+        return htmlentities($string ?? '',ENT_QUOTES,$encoding = 'UTF-8');
     }
 
     // Makes sure a string is safe as an href

--- a/vendor/tsugi/lib/src/Util/U.php
+++ b/vendor/tsugi/lib/src/Util/U.php
@@ -45,7 +45,7 @@ class U {
     }
 
     public static function htmlspec_utf8($string) {
-        if ( is_string($string) ) return htmlspecialchars($string,ENT_QUOTES,$encoding = 'UTF-8');
+        if ( is_string($string) ) return htmlspecialchars($string ?? '',ENT_QUOTES,$encoding = 'UTF-8');
         return $string;
     }
 
@@ -384,7 +384,7 @@ class U {
         if ( $CFG->DEVELOPER === TRUE ) {
             if ( strlen($DEBUG_STRING) > 0 ) {
                 echo("\n<pre>\n");
-                echo(htmlentities($DEBUG_STRING));
+                echo(htmlentities($DEBUG_STRING ?? ''));
                 echo("\n</pre>\n");
             }
         }


### PR DESCRIPTION
Fix for Issue 146:

Error shown on page:
> Deprecated: htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/vhosts/tsugi/vendor/tsugi/lib/src/Util/U.php on line 53

PHP 8.1 deprecates these calls, it does not make them errors. The purpose of deprecation is to give authors advance notice to fix their code, so you and the authors of libraries you use have until PHP 9.0 comes out to fix things.

Fix is:
> public static function htmlent_utf8($string) {
>     return htmlentities($string ?? '',ENT_QUOTES,$encoding = 'UTF-8');
> }