### PR TITLE
Dark mode

### DIFF
--- a/config-dist.php
+++ b/config-dist.php
@@ -135,6 +135,8 @@ $CFG->adminpw = false;
     "font-family" => "'Muli', sans-serif", // Font family
     "font-size" => "14px", // This is the base font size used for body copy. Headers,etc. are scaled off this value
 );*/
+// $CFG->theme_base = "#0d47a1"; // Tsugi Blue
+// $CFG->theme_dark_mode = false;
 
 // If we are running Embedded Tsugi we need to set the
 // "course title" for the course that represents

--- a/lti/store/test.php
+++ b/lti/store/test.php
@@ -3,6 +3,7 @@
 use \Tsugi\Util\U;
 use \Tsugi\Util\LTI;
 use \Tsugi\Core\LTIX;
+use \Tsugi\UI\Theme;
 
 require_once "../../config.php";
 require_once "../../admin/admin_util.php";
@@ -150,7 +151,8 @@ echo("</center>\n");
             }
 
             $parms['launch_presentation_return_url'] = $rest_path->current . '/return';
-
+            // Add the dark mode preference from the Theme (defaulting to false)
+            $parms['theme_dark_mode'] = Theme::$dark_mode ? 'true' : 'false';
             $tool_consumer_instance_guid = $lmsdata['tool_consumer_instance_guid'];
             $tool_consumer_instance_description = $lmsdata['tool_consumer_instance_description'];
 

--- a/store/test.php
+++ b/store/test.php
@@ -3,6 +3,7 @@
 use \Tsugi\Util\U;
 use \Tsugi\Util\LTI;
 use \Tsugi\Core\LTIX;
+use \Tsugi\UI\Theme;
 
 if ( ! defined('COOKIE_SESSION') ) define('COOKIE_SESSION', true);
 require_once "../config.php";
@@ -155,7 +156,8 @@ if ( $outcomes ) {
 }
 
 $parms['launch_presentation_return_url'] = $rest_path->current . '/return';
-
+// Add the dark mode preference from the Theme (defaulting to false)
+$parms['theme_dark_mode'] = Theme::$dark_mode ? 'true' : 'false';
 $tool_consumer_instance_guid = $lmsdata['tool_consumer_instance_guid'];
 $tool_consumer_instance_description = $lmsdata['tool_consumer_instance_description'];
 

--- a/vendor/tsugi/lib/src/Config/ConfigInfo.php
+++ b/vendor/tsugi/lib/src/Config/ConfigInfo.php
@@ -342,6 +342,18 @@ class ConfigInfo {
     public $theme;
 
     /**
+     * The color to be used as the theme base
+     * This could optionally be overridden by a launch parameter
+     */
+    public $theme_base;
+
+    /**
+     * A boolean indicator as to whether dark mode should be used
+     * This could optionally be overridden by a launch parameter
+     */
+    public $theme_dark_mode;
+
+    /**
      * The path to an LTI-launch error handling page
      *
      * When the LTI runtime (LTIX.php) is lost and confused because

--- a/vendor/tsugi/lib/src/Controllers/Profile.php
+++ b/vendor/tsugi/lib/src/Controllers/Profile.php
@@ -49,7 +49,15 @@ class Profile extends Controller {
         $profile = json_decode($profile_row['json']);
         if ( ! is_object($profile) ) $profile = new \stdClass();
 
-        // Load data from the profile
+        $themeId = 0;
+        // Load data from the profile, if it exists
+        if (isset($profile->theme_override)) {
+            if ($profile->theme_override == 'light') {
+                $themeId = 1;
+            } else if ($profile->theme_override == 'dark') {
+                $themeId = 2;
+            }
+        }
         $subscribe = isset($profile->subscribe) ? $profile->subscribe+0 : false;
         $map = isset($profile->map) ? $profile->map+0 : false;
         $lat = isset($profile->lat) ? $profile->lat+0.0 : 0.0;
@@ -112,10 +120,32 @@ echo(' ('.$_SESSION['email'].")</h4>\n");
 
         <p>
         <form method="POST">
-        <div class="control-group pull-right" style="margin-top: 20px">
-        <button type="submit" class="btn btn-primary visible-phone">Save</button>
-        <input class="btn btn-warning" type="button" onclick="location.href='<?= $CFG->apphome ?>/index.php'; return false;" value="Cancel"/>
-        </div>
+            <div style="display: flex; justify-content: space-between;">
+                <div class="control-group">
+                    <div class="controls">
+                        <p>Would you like to set a theme override?</p>
+                        <em>Overrides will only show if theme information is set in the launch data (such as from an LMS) or configured.</em>
+                        <label class="radio">
+                            <?php self::radio('theme',0,$themeId); ?> >
+                            Use the default configuration
+                        </label>
+                        <label class="radio">
+                            <?php self::radio('theme',1,$themeId); ?> >
+                            Use light theme
+                        </label>
+                        <label class="radio">
+                            <?php self::radio('theme',2,$themeId); ?> >
+                            Use dark theme
+                        </label>
+                    </div>
+                </div>
+                <div class="control-group pull-right" style="margin-top: 20px">
+                    <button type="submit" class="btn btn-primary visible-phone">Save</button>
+                    <input class="btn btn-warning" type="button" onclick="location.href='<?= $CFG->apphome ?>/index.php'; return false;" value="Cancel"/>
+                </div>
+            </div>
+            <hr class="hidden-phone"/>
+            <div style="display: flex; justify-content: space-between;">
         <div class="control-group">
         <div class="controls">
         How much mail would you like us to send?
@@ -137,7 +167,11 @@ Send me notification mail for important things like my assignment was graded.
 </label>
 </div>
 </div>
-<hr class="hidden-phone"/>
+<div class="control-group pull-right" style="margin-top: 20px">
+    <button type="submit" class="btn btn-primary visible-phone">Save</button>
+    <input class="btn btn-warning" type="button" onclick="location.href='<?= $CFG->apphome ?>/index.php'; return false;" value="Cancel"/>
+</div>
+</div>
 <?php if ( isset($CFG->google_map_api_key) && ! $CFG->OFFLINE ) { ?>
     <hr class="hidden-phone"/>
         How would you like to be shown in maps.<br/>
@@ -200,9 +234,10 @@ Send me notification mail for important things like my assignment was graded.
         if ( $num == $val ) echo(' selected ');
     }
 
-    public static function checkbox($val) {
-        echo(' value="1" ');
-        if ( $val == 1 ) echo(' checked ');
+    public static function checkbox($var, $num, $initialVal) {
+        $ret = '<input type="checkbox" name="'.$var.'" id="'.$var.$num.'" value="'.$num.'" ';
+        if ( $num == $initialVal ) $ret .= ' checked ';
+        echo($ret);
     }
 
     public static function postProfile(Application $app)
@@ -230,11 +265,21 @@ Send me notification mail for important things like my assignment was graded.
         if ( ! is_object($profile) ) $profile = new \stdClass();
 
         $profile->subscribe = $_POST['subscribe']+0 ;
+
+        if ($_POST['theme'] == 1) {
+            $profile->theme_override = 'light';
+        } else if ($_POST['theme'] == 2) {
+            $profile->theme_override = 'dark';
+        } else {
+            $profile->theme_override = null;
+        }
+        
         if ( isset($_POST['map']) ) {
             $profile->map = $_POST['map']+0 ;
             $profile->lat = $_POST['lat']+0.0 ;
             $profile->lng = $_POST['lng']+0.0 ;
         }
+        echo('HERE');
         $new_json = json_encode($profile);
         $stmt = $PDOX->queryDie(
                 "UPDATE {$CFG->dbprefix}profile SET json= :JSON

--- a/vendor/tsugi/lib/src/Core/LTIX.php
+++ b/vendor/tsugi/lib/src/Core/LTIX.php
@@ -1073,6 +1073,10 @@ class LTIX {
         $sub_caliper_url = U::get($FIXED,'sub_caliper_url');
         if ($sub_caliper_url ) $retval['sub_caliper_url'] = $sub_caliper_url;
 
+        // Get the theme data
+        $retval['theme_base'] = isset($FIXED['theme_base']) ? $FIXED['theme_base'] : null;
+        $retval['theme_dark_mode'] = isset($FIXED['theme_dark_mode']) ? $FIXED['theme_dark_mode'] : null;
+
         return $retval;
     }
 
@@ -1231,6 +1235,10 @@ class LTIX {
         if ( isset($body->{LTI13::DEEPLINK_CLAIM}) ) {
             $retval['lti13_deeplink'] = $body->{LTI13::DEEPLINK_CLAIM};
         }
+
+        // Get the theme data
+        $retval['theme_base'] = isset($body->theme_base) ? $body->theme_base : null;
+        $retval['theme_dark_mode'] = isset($body->theme_dark_mode) ? $body->theme_dark_mode : null;
 
         return $retval;
     }

--- a/vendor/tsugi/lib/src/UI/Output.php
+++ b/vendor/tsugi/lib/src/UI/Output.php
@@ -1346,8 +1346,14 @@ EOF;
         ini_set('zlib.output_compression', false);
     }
 
+    /** Retrieves or generates a theme based on optional specs (base color, dark mode flag).
+     *  $TSUGI_LAUNCH theme data is provided, it will override the $CFG data.
+     *  Otherwise, $CFG theme data will be used (either a theme_base or legacy theme data)
+     *  If $CFG and $TSUGI_LAUNCH theme data aren't provided, regular defaults will be used.
+     */
     public static function get_theme() {
         global $CFG, $TSUGI_LAUNCH;
+        $PDOX = LTIX::getConnection(); // Not globally accessible in tool details
 
         // TODO: Enable this
         if ( false && is_object($TSUGI_LAUNCH) ) {
@@ -1355,21 +1361,71 @@ EOF;
             if ( is_array($theme) ) return $theme;
         }
 
+        /** Theme generation from a base color */
+
         // Check if we are to construct a theme
-        if ( is_object($TSUGI_LAUNCH) ) {
-            $theme_base = $TSUGI_LAUNCH->settingsCascade('theme-base', false);
-            $dark_mode = $TSUGI_LAUNCH->settingsCascade('theme-dark-mode', false);
-            $dark_mode = ($dark_mode == 'true') || ($dark_mode == 'yes');
-            if ( U::isValidCSSColor($theme_base) ) {
-                $theme = Theme::getLegacyTheme($theme_base, $dark_mode);
-                $TSUGI_LAUNCH->session_put('tsugi_theme', $theme);
-                return $theme;
+        $theme_base = isset($CFG->theme_base) ? $CFG->theme_base : null;
+        $dark_mode = isset($CFG->theme_dark_mode) && Theme::isActive($CFG->theme_dark_mode) ? $CFG->theme_dark_mode : null;
+
+        // Override config values with launch values, if they exist
+        if (is_object($TSUGI_LAUNCH)) {
+            $launched_theme_base = null;
+            $launched_dark_mode = null;
+            if (isset($_SESSION) && isset($_SESSION['lti_post']) && isset($_SESSION['lti_post']['theme_base'])) {
+                $launched_theme_base = $_SESSION['lti_post']['theme_base'];
+            }
+            if (isset($_SESSION) && isset($_SESSION['lti_post']) && isset($_SESSION['lti_post']['theme_dark_mode'])) {
+                $launched_dark_mode = $_SESSION['lti_post']['theme_dark_mode'];
+            }
+            if (isset($launched_theme_base)) {
+                $theme_base = U::isValidCSSColor($launched_theme_base) ? $launched_theme_base : $theme_base;
+            }
+            if (isset($launched_dark_mode)) {
+                $dark_mode = Theme::isActive($launched_dark_mode);
             }
         }
 
-        // Construct a theme the old way
+        // Override the config AND launch values if the user's preference is set in the $_SESSION
+        if (isset($_SESSION) && isset($_SESSION['profile_id'])) {
+            $stmt = $PDOX->queryDie(
+                "SELECT json FROM {$CFG->dbprefix}profile WHERE profile_id = :PID",
+                array('PID' => $_SESSION['profile_id'])
+            );
+            $profile_row = $stmt->fetch(\PDO::FETCH_ASSOC);
+            if (!empty($profile_row) && !is_null($profile_row['json'])) {
+                $profile = json_decode($profile_row['json']);
+                if (isset($profile->theme_override)) {
+                    if ($profile->theme_override == 'dark') {
+                        $dark_mode = true;
+                    } else if ($profile->theme_override == 'light') {
+                        $dark_mode = null;
+                    }
+                }
+            }
+        }
+
+        // Set dark mode configuration on the theme so apps can check
+        // Example: conditional rendering of a twitter embed attribute
+        Theme::$dark_mode = $dark_mode;
+        Theme::$theme_base = $theme_base;
+
+        // Generate the theme
+        if (isset($theme_base) && U::isValidCSSColor($theme_base)) {
+            $theme = Theme::getLegacyTheme($theme_base, $dark_mode);
+            // Default any remaining values that weren't already configured
+            $theme = Theme::defaults($theme);
+            if (is_object($TSUGI_LAUNCH)) $TSUGI_LAUNCH->session_put('tsugi_theme', $theme);
+            return $theme;
+        }
+
+        /** Legacy theming */
+
         $theme = array();
-        if ( isset($CFG->theme) && is_array($CFG->theme) ) {
+        if ($dark_mode && isset($CFG->theme_dark) && is_array($CFG->theme_dark)) {
+            // If we are at this point and dark mode was requested but a provided or generated theme wasn't used, may use config
+            $theme = $CFG->theme_dark;
+        } else if (isset($CFG->theme) && is_array($CFG->theme)) {
+            // Otherwise use the non-dark theme configuration
             $theme = $CFG->theme;
         }
 
@@ -1379,7 +1435,7 @@ EOF;
         foreach($theme as $name => $value ) {
             if ( is_object($TSUGI_LAUNCH) ) {
                 $check = $TSUGI_LAUNCH->settingsCascade($name, $value);
-                if ( U::isValidCSSColor($check) ) $theme[$name] = $check;
+                if (isset($check) && U::isValidCSSColor($check) ) $theme[$name] = $check;
             }
         }
 

--- a/vendor/tsugi/lib/src/UI/Theme.php
+++ b/vendor/tsugi/lib/src/UI/Theme.php
@@ -6,6 +6,9 @@ use \Tsugi\Util\U;
 use \Tsugi\Util\Color;
     
 class Theme {
+
+    public static $dark_mode = false;
+    public static $theme_base = null;
     
     /**
      * Get default theme values from a configured theme or the actual defaults
@@ -20,7 +23,9 @@ class Theme {
             "primary-border" => U::get($theme, 'primary-border', self::adjustBrightness($primary,-0.075)),
             "primary-darker" => U::get($theme, 'primary-darker', self::adjustBrightness($primary,-0.1)),
             "primary-darkest" => U::get($theme, 'primary-darkest', self::adjustBrightness($primary,-0.175)),
-            'background-color' => U::get($theme, 'background-color', '#FFFFFF'),
+            "background-color" => U::get($theme, 'background-color', '#FFFFFF'),
+            "background-focus" => U::get($theme, 'background-focus', '#F5F5F5'),
+            "background-accent" => U::get($theme, 'background-accent', $primary),
             "secondary" => U::get($theme, 'secondary', $secondary),
             "secondary-menu" => U::get($theme, 'secondary-menu', $secondary),
             "text" => U::get($theme, 'text', '#111111'),
@@ -28,6 +33,11 @@ class Theme {
             "font-family" => U::get($theme, 'font-family', 'sans-serif'),
             "font-size" => U::get($theme, 'font-size', '14px'),
         );
+    }
+
+    public static function isActive($themeIndicator=false)
+    {
+        return ($themeIndicator == 'true') || ($themeIndicator == 'yes');
     }
 
     /**
@@ -129,13 +139,14 @@ class Theme {
     public static function getLegacyTheme($tsugi_dark, $dark_mode) {
     
         $tsuginames = self::deriveTsugiColors($tsugi_dark);
-        if ( $dark_mode ) {
+        if (Theme::isActive($dark_mode)) {
             $tusgitolegacy = array(
-                'tsugi-theme-light-text' => ['text', 'primary-darkest'],
-                'tsugi-theme-light' => ['text-light', 'primary', 'secondary-menu'],
+                'tsugi-theme-light-text' => ['text'],
+                'tsugi-theme-light' => ['text-light', 'secondary-menu', 'secondary'],
                 'tsugi-theme-light-darker' => 'primary-darker',
                 'tsugi-theme-light-accent' => 'primary-border',
-                'tsugi-theme-dark' => 'primary-menu',
+                'tsugi-theme-dark' => ['primary', 'primary-menu'],
+                'tsugi-theme-dark-background-tint' => 'background-focus',
                 'tsugi-theme-dark-background' => 'background-color',
             );
         } else {
@@ -144,7 +155,8 @@ class Theme {
                 'tsugi-theme-dark' => ['primary', 'primary-menu', 'text-light'],
                 'tsugi-theme-dark-darker' => 'primary-darker',
                 'tsugi-theme-dark-accent' => 'primary-border',
-                'tsugi-theme-light' => 'secondary',
+                'tsugi-theme-light' => [ 'secondary', 'secondary-menu'],
+                "tsugi-theme-light-background-tint" => 'background-focus',
                 'tsugi-theme-light-background' => 'background-color',
             );
         }
@@ -210,7 +222,8 @@ class Theme {
         $lightness_dark_accent = ($tsugi_dark_hsl[2] + $dark_inner_hsl[2]) / 2.0;
     
         $tsuginames = array(
-            "tsugi-theme-dark-background" => $outerpair[0],
+            "tsugi-theme-dark-background" => "#1f2225",
+            "tsugi-theme-dark-background-tint" => "#3a3f45",
             "tsugi-theme-dark-text" =>  Color::hex(self::hslToRgb($hue, $sat_dark*0.5, $lightness_darker)),
             "tsugi-theme-dark-darker" => Color::hex(self::hslToRgb($hue, $sat_dark, $lightness_darker)),
             "tsugi-theme-dark" =>  $tsugi_dark,
@@ -220,7 +233,8 @@ class Theme {
             "tsugi-theme-light" => Color::hex(self::hslToRgb($hue, $sat_light, $lightness_light - ($ldelta * 0.6))),
             "tsugi-theme-light-lighter" => Color::hex(self::hslToRgb($hue, $sat_light, $lightness_light - ($ldelta * 0.3))),
             "tsugi-theme-light-text" => Color::hex(self::hslToRgb($hue, $sat_light*0.5, $lightness_light - ($ldelta * 0.3))),
-            "tsugi-theme-light-background" => $outerpair[1],
+            "tsugi-theme-light-background-tint" => Color::hex(self::hslToRgb($hue, $sat_light*0.5, $lightness_light - ($ldelta * 0.4))),
+            "tsugi-theme-light-background" => '#FFFFFF',
         );
     
         return $tsuginames;


### PR DESCRIPTION
Included in this PR is a possible next step for the dark mode implementation, if it may be of use!

- $CFG variable that can set a theme base color and dark mode flag
- Launch parameters for 1.1 and 1.3 that will override the $CFG values
- A new option in the profile menu, which overrides launch and $CFG values
- Note: it is reflected in the store's Test page, but based on the logged in user profile, not any test user profiles

Between these dark mode changes and other general store and styling customizations, I ended up making a new stylesheet for tsugi-static. I'll plan to submit a PR for tsugi-static as well as another Tsugi PR for some styling updates to the store.

Please see below for the dark mode changes (with the tsugi-static changes).

![image](https://user-images.githubusercontent.com/6700647/224165461-8a32373f-9415-4999-9330-2c2b20275873.png)

![image](https://user-images.githubusercontent.com/6700647/224166067-23ee8789-1c02-48bf-8524-7e05dc8fef1e.png)
