### PR TITLE
Store styling updates

### DIFF
--- a/lti/store/details.php
+++ b/lti/store/details.php
@@ -17,6 +17,9 @@ $OUTPUT->header();
     <link rel="stylesheet" type="text/css"
           href="<?= $CFG->staticroot ?>/plugins/jquery.bxslider/jquery.bxslider.css"/>
     <style type="text/css">
+        #body_container.container-fluid {
+            padding: 0;
+        }
         .row {
             margin: 0;
         }
@@ -28,6 +31,141 @@ $OUTPUT->header();
         .keyword-span {
             text-transform: lowercase;
         }
+        .overlay{
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 10000;
+            display: none;
+            background-color: rgba(0,0,0,0.5); /*dim the background*/
+            justify-content: center;
+            align-items: center;
+            }
+            #overlay_img {
+                max-width: 90%;
+            }
+            .slider-thumbnail {
+                height: 100%;
+                display: flex;
+                align-items: center;
+                background-color: var(--background-focus);
+            }
+            .detail-header {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                padding: 2rem;
+                background-color: var(--background-focus);
+                border-bottom: 8px solid var(--secondary);
+                flex-wrap: wrap;
+            }
+            .detail-header-icon {
+                font-size: 3rem;
+                margin-right: 20px;
+                color: var(--text);
+            }
+            .detail-header-text {
+                font-size: 3rem;
+                line-height: 3rem;
+                color: var(--text);
+            }
+            @media(max-width: 768px) {
+                .title-container {
+                    display: flex;
+                    width: 100%;
+                    justify-content: center;
+                }
+                .install-button-container {
+                    width: 100%;
+                    text-align: center;
+                }
+                .install-button-container .btn {
+                    width: 275px;
+                    margin-top: 20px;
+                }
+            }
+            .breadcrumb {
+                background-color: var(--background-color);
+                margin-bottom: 5px;
+                padding: 5px 15px;
+            }
+            .breadcrumb>.active {
+                color: var(--text-light);
+            }
+            .summary-text {
+                margin-bottom: 40px;
+                font-size: large;
+            }
+            .video-frame {
+                max-width: 100%;
+            }
+            .content-container {
+                display: flex;
+                padding: 20px;
+                padding-top: 40px;
+                flex-wrap: wrap;
+                justify-content: space-around;
+                gap: 20px;
+            }
+            .summary-column {
+                display: flex;
+                flex-direction: column;
+                width: 100%;
+                max-width: 600px;
+                justify-content: flex-start;
+            }
+            .details-column {
+                width: 275px;
+                display: flex;
+                flex-direction: column;
+                justify-content: flex-start;
+            }
+            .details-column input {
+                margin-bottom: 20px;
+            }
+            .button-container {
+                display: flex;
+                justify-content: center;
+            }
+            .button-container input {
+                width: 100%;
+            }
+            .tool-link-container {
+                padding: 8px 0;
+            }
+            .sidebar-header {
+                font-size: large;
+            }
+            a.tool-url-link {
+                text-decoration: none;
+                padding: 0;
+            }
+            a.tool-url-link:hover, a.tool-url-link:focus, a.tool-url-link:active {
+                color: var(--text-light);
+                text-decoration: none;
+            }
+            .bx-wrapper .bx-viewport {
+                background-color: var(--background-focus);
+                border-width: 2px;
+                border-color: var(--secondary);
+                box-shadow: none;
+                -webkit-box-shadow: none;
+                -moz-box-shadow: none;
+            }
+            .bxslider {
+                display: flex;
+                align-items: center;
+                height: 315px;
+                width: 560px;
+            }
+            .bx-pager-item {
+                line-height: normal;
+            }
+            body .bx-wrapper .bx-pager.bx-default-pager a {
+                border: 1px solid var(--text);
+            }
     </style>
 <?php
 
@@ -35,6 +173,13 @@ $registrations = findAllRegistrations(false, true);
 if ( count($registrations) < 1 ) $registrations = false;
 
 $OUTPUT->bodyStart();
+?>
+<div id="overlay" class="overlay" onclick="document.getElementById('overlay').style.display = 'none';" >
+    <!-- NEED TO RESTYLE OVERLAY -->
+    <img id="overlay_img" src="<?= $OUTPUT->getSpinnerUrl(); ?>">
+    <!-- <img id="overlay_img" style="width:90%;margin-top: 50px;" src="<?= $OUTPUT->getSpinnerUrl(); ?>"> -->
+</div>
+<?php
 $OUTPUT->topNav();
 $OUTPUT->flashMessages();
 
@@ -55,6 +200,7 @@ if ( ! isset($registrations[$install])) {
 $tool = $registrations[$install];
 
 $screen_shots = U::get($tool, 'screen_shots');
+$video = U::get($tool, 'video');
 if ( !is_array($screen_shots) || count($screen_shots) < 1 ) $screen_shots = false;
 
 $title = $tool['name'];
@@ -102,29 +248,8 @@ $register_good = $json_obj && isset($json_obj->name);
         <p>App Store Canvas Configuration URL<br/>
             <a href="<?= $CFG->wwwroot ?>/lti/store/canvas-config.xml" target="_blank"><?= $CFG->wwwroot ?>/lti/store/canvas-config.xml</a></p>
     </div>
-<?php
 
-if ( $fa_icon ) {
-    echo('<span class="hidden-xs fa '.$fa_icon.' fa-2x" style="color: var(--primary); float:right; margin: 2px"></span>');
-}
-echo("<b>".htmlent_utf8($title)."</b>\n");
-if (is_array($keywords)) {
-    sort($keywords);
-    echo('<p class="keywords">Tags: <span class="keyword-span">'.implode(", ", $keywords).'</span></p>');
-}
-echo('<p class="hidden-xs">'.htmlent_utf8($text)."</p>\n");
-
-echo("<p class=\"tool-options\">\n");
-echo('<a href="../index.php" class="btn btn-warning" role="button">Back to Store</a>');
-echo(' ');
-echo('<a href="#" class="btn btn-default" role="button" onclick="showModal(\'Tool URLs\',\'url-dialog\');">Tool URLs</a>');
-echo(' ');
-echo('<a href="'.$rest_path->parent.'/test/'.urlencode($install).'" class="btn btn-default" role="button">Test</a> ');
-echo(' ');
-echo('<button type="button" class="btn btn-success" role="button" data-toggle="modal" data-target="#'.urlencode($install).'_modal"><span class="fa fa-plus" aria-hidden="true"></span> Install</button>');
-echo("</p>\n");
-
-?>
+    <!-- Install modal -->
     <div id="<?=urlencode($install)?>_modal" class="modal fade" role="dialog">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -150,14 +275,128 @@ echo("</p>\n");
             </div>
         </div>
     </div>
-<?php
 
-if ( $screen_shots ) {
-    echo('<div class="row">'."\n");
-    echo('<div class="col-sm-4">'."\n");
-}
+    <!-- Banner/Header Section -->
+    <div class="header-back-nav">
+        <ol class="breadcrumb">
+        <li><a href="../index.php">Store</a></li>
+        <li class="active"><?= $title ?></li>
+        </ol>
+    </div>
+    <div class="detail-header">
+        <div class="title-container">
+            <?php
+            if ( $fa_icon ) {
+                ?>
+                <span class="fa <?= $fa_icon; ?> detail-header-icon"></span>
+                <?php
+            }
+            ?>
+            <span class="detail-header-text"><?= htmlent_utf8($title); ?></span>
+        </div>
+        <div class="install-button-container">
+        <?php
+        echo('<button type="button" class="btn btn-success" role="button" data-toggle="modal" data-target="#'.urlencode($install).'_modal"><span class="fa fa-plus" aria-hidden="true"></span> Install</button>');
+        ?>
+        </div>
+    </div>
 
-echo("<ul>\n");
+    <div class="content-container">
+    <div class="summary-column">
+        <span class="summary-text"> <?= htmlent_utf8($text); ?></span>
+        <?php
+        if ($video || $screen_shots) {
+            ?>
+            <div class="bxslider">
+                <?php
+                
+                if (is_string($video)) { ?>
+                    <iframe class="video-frame" height="315" width="560" src="<?= $video; ?>" frameborder="0" scrolling="0" allow="autoplay *; encrypted-media *; fullscreen *; picture-in-picture *;" allowfullscreen></iframe>
+                    <?php
+                }
+                if ($screen_shots) {
+                    foreach($screen_shots as $idx=>$screen_shot ) { ?>
+                        <div class="slider-thumbnail" id="slider-thumbnail-<?= $idx; ?>"><img src="<?= $screen_shot; ?>" title="<?= htmlentities($title); ?>"></div>
+                        <?php
+                    } 
+                }
+            ?>
+            </div>
+        <?php
+        }
+        ?>
+    </div>
+    <div class="details-column">
+        <?php
+            
+            echo('<form method="GET" style="display:inline" action="'.$rest_path->parent.'/test/'.urlencode($install).'">');
+            echo('<div class="button-container">');
+            echo('<input type="submit" class="btn btn-primary" value="Try It"></form> ');
+            echo('</div>');
+            if ( is_array(U::get($tool, 'languages')) ) {
+                ?>
+                <div class="tool-link-container">
+                    <div class="sidebar-header">Languages</div>
+                    <?php
+                    $first = true;
+                    foreach(U::get($tool, 'languages') as $language) {
+                        if ( ! $first ) echo(', ');
+                        $first = false;
+                        echo(htmlentities($language));
+                    }
+                    ?>
+                </div>
+                <?php
+            }
+            if ( is_string(U::get($tool, 'license')) ) {
+                ?>
+                <div class="tool-link-container">
+                    <div class="sidebar-header">License</div>
+                    <?php
+                        echo(htmlentities(U::get($tool, 'license')));
+                    ?>
+                </div>
+                <?php
+            }
+            $source_url = U::get($tool, 'source_url');
+            if ( is_string($source_url) ) {
+                ?>
+                <div class="tool-link-container">
+                    <a href="<?= $source_url; ?>" target="_blank" class="tool-url-link sidebar-header">Source Code <span class="fa fa-chevron-right"></span></a>
+                </div>
+                <?php
+            }
+            echo('<div class="tool-link-container">');
+            echo('<a href="#" class="tool-url-link sidebar-header" role="button" onclick="showModal(\'Tool URLs\',\'url-dialog\');">Tool URLs <span class="fa fa-chevron-right"></span></a>');
+            echo('</div>');
+
+            if (is_array($keywords)) {
+                sort($keywords);
+                ?>
+                <div class="tool-link-container">
+                    <div class="sidebar-header">Tags</div>
+                    <h3 style="margin-top: 0;">
+
+                    <?php
+                        foreach ($keywords as $tag) {
+                            ?>
+                                <span class="label label-default"><?= $tag; ?></span>
+                            <?php
+                        }
+                    ?>
+                    </h3>
+                </div>
+                <?php
+            }
+            
+            ?>
+            <div class="tool-link-container">
+                <div class="sidebar-header">Additional Details</div>
+            </div>
+            <?php
+$script = isset($tool['script']) ? $tool['script'] : "index";
+$path = $tool['url'];
+echo("<p><ul>\n");
 if ( isset($CFG->privacy_url) ) {
     echo('<li><p><a href="'.$CFG->privacy_url.'"
        target="_blank">'._m('Privacy Policy').'</a></p></li>'."\n");
@@ -197,32 +436,9 @@ if ( $CFG->launchactivity ) {
     echo(_m('Can send analytics to learning record store.'));
     echo("</p></li>\n");
 }
-if ( is_array(U::get($tool, 'languages')) ) {
-    echo('<li><p>');
-    echo(_m('Languages:'));
-    echo(' ');
-    $first = true;
-    foreach(U::get($tool, 'languages') as $language) {
-        if ( ! $first ) echo(', ');
-        $first = false;
-        echo(htmlentities($language));
-    }
-    echo("</p></li>\n");
-}
 if ( isset($CFG->sla_url) ) {
     echo('<li><p><a href="'.$CFG->sla_url.'"
        target="_blank">'._m('Service Level Agreement').'</a></p></li>'."\n");
-}
-if ( is_string(U::get($tool, 'license')) ) {
-    echo('<li><p>');
-    echo(_m('License:'));
-    echo(' ');
-    echo(htmlentities(U::get($tool, 'license')));
-}
-$source_url = U::get($tool, 'source_url');
-if ( is_string($source_url) ) {
-    echo('<li><p><a href="'.$source_url.'"
-       target="_blank">'._m('Source code').'</a></p></li>'."\n");
 }
 
 if ( isset($CFG->google_classroom_secret) ) {
@@ -252,19 +468,8 @@ echo("</p></li>\n");
 
 
 echo("</ul>\n");
-
-if ( $screen_shots ) {
-    echo("<!-- .col-sm-4--></div>\n");
-    echo('<div class="col-sm-8">'."\n");
-    echo("<center>\n");
-    echo('<div class="bxslider">');
-    foreach($screen_shots as $screen_shot ) {
-        echo('<div><img title="'.htmlentities($title).'" onclick="$(\'#popup-image\').attr(\'src\',this.src);showModal(this.title,\'image-dialog\');" src="'.$screen_shot.'"></div>'."\n");
-    }
-    echo("</center>\n");
-    echo("<!-- .col-sm-8--></div>\n");
-    echo("</div>\n");
-}
+echo("</div>\n");
+echo("</div>\n");
 
 echo("<!-- \n");print_r($tool);echo("\n-->\n");
 $OUTPUT->footerStart();
@@ -276,10 +481,23 @@ $OUTPUT->footerStart();
             $('.bxslider').bxSlider({
                 useCSS: false,
                 adaptiveHeight: false,
-                slideWidth: "240px",
+                // slideWidth: "240px",
                 infiniteLoop: false,
-                maxSlides: 3
+                // maxSlides: 3
             });
+
+            <?php
+            if ($screen_shots) {
+                foreach($screen_shots as $idx=>$screen_shot) {
+                    ?>
+                    $('#slider-thumbnail-<?= $idx; ?>').click(function () {
+                        $('#overlay_img').attr('src', "<?= $screen_shot; ?>");
+                        document.getElementById('overlay').style.display = 'flex';
+                    });
+                    <?php
+                }
+            }
+            ?>
         });
     </script>
 <?php

--- a/lti/store/index.php
+++ b/lti/store/index.php
@@ -61,96 +61,195 @@ $debug = false;  /* Pause when sending back */
 
 $OUTPUT->header();
 ?>
-<style>
-    .panel-default {
-        box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-        position: relative;
+    <link rel="stylesheet" type="text/css" href="<?= $CFG->staticroot ?>/plugins/jquery.bxslider/jquery.bxslider.css"/>
+    <style>
+        .app-container {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 16px;
+        }
+        .app {
+            width: 265px;
+            box-sizing: border-box;
+        }
+        .app.featured {
+            width: 90%;
+            max-width: 350px;
+        }
+        .tool-icon {
+            color: var(--secondary);
+            margin-left: 8px;
+        }
+        .featured-panel-container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            padding-top: 20px;
+        }
+        .panel {
+            border: 1px solid transparent;
+            background-color: transparent;
+        }
+        .panel-default {
+            position: relative;
+            box-shadow: none;
+            -webkit-box-shadow: none;
+        }
+        .panel-default:hover {
+            border-color: var(--background-focus);
+        }
+        .panel-description {
+            display:block;
+            overflow:hidden;
+            height: 8em;
+            max-height: 8em;
+        }
+        .panel-default > .panel-heading {
+            border-bottom: none;
+            background: var(--primary);
+            color: #fff;
+        }
+        .panel-default > .panel-heading .heading-container h3 {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            margin: 0 0.5rem;
+            font-weight: 500;
+            line-height: normal;
+            color: #fff;
+        }
+        .panel-body {
+            border: 1px solid var(--background-focus);
+            border-top: 5px solid var(--secondary);
+            padding: 15px 25px 20px;
+        }
+        .panel-heading {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            width: 100%;
+            min-height: 75px;
+            flex-wrap: wrap;
+        }
+        .panel-heading a {
+            font-weight: 300;
+            width: 100%;
+        }
+        .heading-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            width: 100%;
+        }
+        .heading-container span.fa {
+            font-size: 2.75rem;
+        }
+        h3.phase-title {
+            padding-left: 15px;
+        }
+        .keywords {
+            font-size: .85em;
+            font-style: italic;
+            color: #666;
+            margin: 0;
+            padding: 0;
+        }
+        .keyword-span {
+            text-transform: lowercase;
+        }
+        /* Created with cssportal.com CSS Ribbon Generator */
+        .ribbon {
+            position: absolute;
+            left: -5px; top: -5px;
+            z-index: 1;
+            overflow: hidden;
+            width: 75px; height: 75px;
+            text-align: right;
+        }
+        .ribbon span {
+            font-size: 14px;
+            font-weight: bold;
+            color: #FFF;
+            text-transform: uppercase;
+            text-align: center;
+            line-height: 20px;
+            transform: rotate(-45deg);
+            -webkit-transform: rotate(-45deg);
+            width: 100px;
+            display: block;
+            background: #dc3545;
+            box-shadow: 0 3px 10px -5px rgba(0, 0, 0, 1);
+            position: absolute;
+            top: 19px; left: -21px;
+        }
+        .ribbon span::before {
+            content: "";
+            position: absolute; left: 0; top: 100%;
+            z-index: -1;
+            border-left: 3px solid #dc3545;
+            border-right: 3px solid transparent;
+            border-bottom: 3px solid transparent;
+            border-top: 3px solid #dc3545;
+        }
+        .ribbon span::after {
+            content: "";
+            position: absolute; right: 0; top: 100%;
+            z-index: -1;
+            border-left: 3px solid transparent;
+            border-right: 3px solid #dc3545;
+            border-bottom: 3px solid transparent;
+            border-top: 3px solid #dc3545;
+        }
+        .action-button {
+            width: 100%;
+            margin-top: 15px;
+        }
+        .search-container {
+            padding: 20px 0;
+            display: flex;
+            justify-content: flex-end;
+        }
+        .search-container input {
+            width: 250px;
+        }
+        #loader {
+            position: fixed;
+            left: 0px;
+            top: 0px;
+            width: 100%;
+            height: 100%;
+            background-color: white;
+            margin: 0;
+            z-index: 100;
+        }
+        #XbasicltiDebugToggle {
+            display: none;
+        }
+        .bx-wrapper {
+            margin-bottom: 20px;
+        }
+        .bx-wrapper .bx-pager {
+            bottom: -40px;
+        }
+        .bx-wrapper .bx-viewport {
+        background-color: var(--background-focus);
+        border-width: 2px;
+        border-color: var(--secondary);
+        box-shadow: none;
+        -webkit-box-shadow: none;
+        -moz-box-shadow: none;
     }
-    .panel-default:hover{
-        border: 1px solid #aaa;
+    .bxslider {
+        display: flex;
+        align-items: center;
     }
-    .panel-body h3 {
-        margin-top: 0.5em;
+    .bx-pager-item {
+        line-height: normal;
     }
-    .approw {
-        margin: 0;
+    body .bx-wrapper .bx-pager.bx-default-pager a {
+        border: 1px solid var(--text);
     }
-    .appcolumn {
-        padding: 0 4px;
-    }
-    h3.phase-title {
-        padding-left: 10px;
-    }
-    .keywords {
-        font-size: .85em;
-        font-style: italic;
-        color: #666;
-        margin: 0;
-        padding: 0;
-    }
-    .keyword-span {
-        text-transform: lowercase;
-    }
-    /* Created with cssportal.com CSS Ribbon Generator */
-    .ribbon {
-        position: absolute;
-        left: -5px; top: -5px;
-        z-index: 1;
-        overflow: hidden;
-        width: 75px; height: 75px;
-        text-align: right;
-    }
-    .ribbon span {
-        font-size: 14px;
-        font-weight: bold;
-        color: #FFF;
-        text-transform: uppercase;
-        text-align: center;
-        line-height: 20px;
-        transform: rotate(-45deg);
-        -webkit-transform: rotate(-45deg);
-        width: 100px;
-        display: block;
-        background: #dc3545;
-        box-shadow: 0 3px 10px -5px rgba(0, 0, 0, 1);
-        position: absolute;
-        top: 19px; left: -21px;
-    }
-    .ribbon span::before {
-        content: "";
-        position: absolute; left: 0; top: 100%;
-        z-index: -1;
-        border-left: 3px solid #dc3545;
-        border-right: 3px solid transparent;
-        border-bottom: 3px solid transparent;
-        border-top: 3px solid #dc3545;
-    }
-    .ribbon span::after {
-        content: "";
-        position: absolute; right: 0; top: 100%;
-        z-index: -1;
-        border-left: 3px solid transparent;
-        border-right: 3px solid #dc3545;
-        border-bottom: 3px solid transparent;
-        border-top: 3px solid #dc3545;
-    }
-    #box {
-        margin-top: 1em;
-    }
-#loader {
-      position: fixed;
-      left: 0px;
-      top: 0px;
-      width: 100%;
-      height: 100%;
-      background-color: white;
-      margin: 0;
-      z-index: 100;
-}
-#XbasicltiDebugToggle {
-    display: none;
-}
-</style>
+    </style>
 <?php
 
 // Load Lessons Data
@@ -327,7 +426,8 @@ if ( $l && isset($_GET['assignment']) ) {
 
 // Handle the content install
 $content_items = array();
-if ( strlen(U::get($_GET,'radio_value')) > 0 ) {
+$val = U::get($_GET,'radio_value');
+if ( isset($val) && strlen($val) > 0 ) {
     $content_items[] = U::get($_GET,'radio_value');
 }
 foreach($_GET as $k => $v) {
@@ -492,71 +592,46 @@ if ( $registrations && $allow_lti ) {
     echo('<div class="tab-pane fade '.$active.' in" id="box">'."\n");
     $active = '';
 
-    echo('<p class="text-right">
-        <label class="sr-only" for="keywordFilter">Filter by keyword</label>
-        <input type="text" placeholder="Filter by keyword" id="keywordFilter">
-        </p>');
-
+    
     $count = 0;
-    foreach($registrations as $name => $tool ) {
 
-        // This will keep the rows nice
-        if ($count % 3 == 0) {
-            if ($count > 0) {
-                echo('</div>');
+    array_multisort(array_column($registrations, 'name'), SORT_ASC, $registrations);
+
+    $newApps = array_filter($registrations, 'new_apps');
+    $theRest = array_filter($registrations, 'the_rest');
+
+    ?>
+    <div>
+        <div class="bxslider">
+            <?php
+            foreach ($newApps as $name => $newApp)
+            {
+                ?><div class="featured-panel-container"><?php
+                renderAppPanel($name, $newApp, true);
+                ?></div><?php
             }
-            echo('<div class="row approw">');
-        }
+            ?>
+        </div>
+    </div>
+    <?php
 
+    echo('<div class="search-container">
+    <label class="sr-only" for="keywordFilter">Filter by name</label>
+    <input type="text" class="form-control" placeholder="Filter by name" id="keywordFilter">
+    </div>');
+
+    echo ('<div class="app-container">');
+
+    foreach($registrations as $name => $tool ) {
+        
         $title = $tool['name'];
         $text = $tool['description'];
-        $fa_icon = isset($tool['FontAwesome']) ? $tool['FontAwesome'] : false;
-        $icon = false;
-        if ( $fa_icon !== false ) {
-            $icon = $CFG->fontawesome.'/png/'.str_replace('fa-','',$fa_icon).'.png';
-        }
-
-        $keywords = '';
-        if (isset($tool['keywords'])) {
-            sort($tool['keywords']);
-            $keywords = implode(", ", $tool['keywords']);
-        }
-
         $grade_launch = false;
         if ( isset($tool['messages']) && is_array($tool['messages']) &&
             array_search('launch_grade', $tool['messages']) !== false ) {
             $grade_launch = true;
         }
-
-        echo('<div class="col-sm-4 appcolumn">');
-
-        echo('<div class="panel panel-default" data-keywords="'.$keywords.'">');
-
-        $phase = isset($tool['tool_phase']) ? $tool['tool_phase'] : false;
-        if ($phase !== false) {
-            echo('<div class="ribbon ribbon-top-left"><span>'.$phase.'</span></div>');
-        }
-
-        echo('<div class="panel-body">');
-        if ( $fa_icon ) {
-            echo('<a href="index.php?install='.urlencode($name).'">');
-            echo('<span class="fa '.$fa_icon.' fa-2x" style="float:right; margin: 2px"></span>');
-            echo('</a>');
-        }
-        if ($phase !== false) {
-            echo('<h3 class="phase-title">');
-        } else {
-            echo('<h3>');
-        }
-        echo(htmlent_utf8($title)."</h3>");
-        echo('<p>'.htmlent_utf8($text)."</p>");
-        if ($keywords !== '') {
-            echo('<p class="keywords">Tags: <span class="keyword-span">'.$keywords.'</span></p>');
-        }
-        echo("</div><div class=\"panel-footer\">");
-        echo('<button type="button" class="btn btn-success pull-right" role="button" data-toggle="modal" data-target="#'.urlencode($name).'_modal"><span class="fa fa-plus" aria-hidden="true"></span> Install</button>');
-        echo('<a href="details/'.urlencode($name).'" class="btn btn-default" role="button">Details</a>');
-        echo("</div></div></div>\n");
+        renderAppPanel($name, $tool);
 
         // Deep Linking 1.0 / Content Item
         // https://www.imsglobal.org/specs/lticiv1p0/specification
@@ -666,10 +741,9 @@ if ( $registrations && $allow_lti ) {
 
         $count++;
     }
+    echo '</div>';
     if ( $count < 1 ) {
         echo("<p>No available tools</p>\n");
-    } else {
-        echo("</div>");
     }
     echo("</div>\n");
 }
@@ -904,6 +978,78 @@ if ( $l ) foreach($l->lessons->modules as $module) {
 <?php
 
 $OUTPUT->footerStart();
+
+function renderAppPanel($name, $tool, $featured = false, $canInstall = true) {
+    global $CFG;
+    $title = $tool['name'];
+    $text = $tool['description'];
+    $fa_icon = isset($tool['FontAwesome']) ? $tool['FontAwesome'] : false;
+    $icon = false;
+    if ( $fa_icon !== false ) {
+        $icon = $CFG->fontawesome.'/png/'.str_replace('fa-','',$fa_icon).'.png';
+    }
+
+    $keywords = '';
+    if (isset($tool['keywords'])) {
+        sort($tool['keywords']);
+        $keywords = implode(", ", $tool['keywords']);
+    }
+
+    $filterClass = !$featured ? ' filterable' : '';
+    $featuredClass = $featured ? ' featured' : '';
+    
+    echo('<div class="app' . $filterClass . $featuredClass . '">'); 
+    echo('<div class="panel panel-default" data-keywords="'.$keywords.'">');
+
+    $phase = isset($tool['tool_phase']) ? $tool['tool_phase'] : false;
+    if ($phase !== false) {
+        echo('<div class="ribbon ribbon-top-left"><span>'.$phase.'</span></div>');
+    }
+
+    echo('<div class="panel-heading">');
+    echo('<a href="details/'.urlencode($name).'">');
+    echo('<div class="heading-container">');
+    if ($phase !== false) {
+        echo('<h3 class="phase-title">');
+    } else {
+        echo('<h3>');
+    }
+    echo(htmlent_utf8($title)."</h3>");
+    if ( $fa_icon ) {
+        echo('<div><span class="tool-icon fa '.$fa_icon.'"></span></div>');
+    }
+    echo('</div>'); // end heading container
+    echo('</a>');
+    echo('</div><div class="panel-body">');
+    echo('<div class="panel-description js-ellipsis">');
+    echo('<p>'.htmlent_utf8($text)."</p>");
+    if ($keywords !== '') {
+        echo('<p class="keywords">');
+        echo(__('Tags:'));
+        echo('<span class="keyword-span">'.$keywords.'</span></p>');
+    }
+    echo("</div>");
+    if ( isset($_SESSION['gc_count']) || $canInstall ) {
+        echo('<div style="text-align: center;">');
+        echo('<a href="details/'.urlencode($name).'" class="action-button" role="button">More Details</a> ');
+        echo('<button type="button" class="btn btn-primary action-button" role="button" data-toggle="modal" data-target="#'.urlencode($name).'_modal"><span class="fa fa-plus" aria-hidden="true"></span> Install</button>');
+        echo('</div>');
+    } else {
+        echo('<div stlye="display: flex;">');
+        echo('<a href="details/'.urlencode($name).'" class="btn btn-primary action-button" role="button">Details</a> ');
+        echo('</div>');
+    }
+    echo("</div></div></div>\n");
+}
+
+function new_apps($val)
+{
+    return isset($val['tool_phase']) && $val['tool_phase'] === 'new';
+}
+function the_rest($val)
+{
+    return !isset($val['tool_phase']);
+}
 ?>
 
 <script>
@@ -947,17 +1093,18 @@ function toggleLineItem(item, count) {
 
 </script>
 
-
+    <script type="text/javascript" src="static/ftellipsis.js"></script>
+    <script src="<?= $CFG->staticroot ?>/plugins/jquery.bxslider/jquery.bxslider.js"></script>
     <script type="text/javascript">
         var filter = filter || {};
 
         filter.setUpListener = function() {
             $("#keywordFilter").on("keyup", function(){
                 var search = $(this).val().toLowerCase();
-                $(".appcolumn").each(function(){
+                $(".app.filterable").each(function(){
                     var panel = $(this).find("div.panel");
-                    var words = panel.data("keywords");
-                    if (typeof words !== "undefined" && words.toLowerCase().indexOf(search) >= 0) {
+                    var title = $(this).find("h3").text().toLowerCase();
+                    if (title.indexOf(search) >= 0) {
                         $(this).fadeIn("slow");
                         var keywordSpan = panel.find("div.panel-body").find("p.keywords").find("span.keyword-span");
                         var keywordText = keywordSpan.text().toLowerCase();
@@ -997,6 +1144,19 @@ function toggleLineItem(item, count) {
 
         $(document).ready(function() {
             filter.setUpListener();
+
+            $('.bxslider').bxSlider({
+                auto: true,
+                // autoControls: true,
+                pager: true,
+                useCSS: false,
+                adaptiveHeight: false,
+                infiniteLoop: true,
+                // slideWidth: "300px",
+                randomStart: true,
+                speed: 750,
+                pause: 5000,
+            });
         });
 
         // https://stackoverflow.com/questions/4471401/getting-value-of-html-checkbox-from-onclick-onchange-events
@@ -1011,6 +1171,18 @@ function toggleLineItem(item, count) {
             $('.module_all').each(function () { $(this).prop("checked", ! $(this).prop("checked")); } );
             return false;
         }
+    </script>
+    <script>
+    // https://github.com/ftlabs/ftellipsis
+    var forEach = Array.prototype.forEach;
+    var els = document.getElementsByClassName('js-ellipsis');
+
+    forEach.call(els, function(el) {
+        var ellipsis = new Ellipsis(el);
+        ellipsis.calc();
+        ellipsis.set();
+    });
+
     </script>
 <?php
 $OUTPUT->footerend();

--- a/lti/store/test.php
+++ b/lti/store/test.php
@@ -6,7 +6,7 @@ use \Tsugi\Core\LTIX;
 
 require_once "../../config.php";
 require_once "../../admin/admin_util.php";
-require_once("../../dev/dev-data.php");
+require_once("dev-data.php");
 
 // No parameter means we require CONTEXT, USER, and LINK
 $LAUNCH = LTIX::requireData(LTIX::USER);
@@ -16,6 +16,12 @@ $p = $CFG->dbprefix;
 $OUTPUT->header();
 ?>
     <style>
+        #body_container.container-fluid {
+            padding: 0;
+        }
+        .content-container {
+            padding-top: 20px;
+        }
         .card {
             border: 1px solid black;
             margin: 5px;
@@ -33,6 +39,51 @@ $OUTPUT->header();
         }
         #XbasicltiDebugToggle {
             display: none;
+        }
+        #body_container {
+            padding-top: 40px;
+        }
+        .breadcrumb {
+            background-color: var(--background-color);
+            margin-bottom: 5px;
+            padding: 5px 15px;
+        }
+        .breadcrumb>.active {
+            color: var(--text-light);
+        }
+        .test-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 2rem;
+            background-color: var(--background-focus);
+            border-bottom: 8px solid var(--secondary);
+            flex-wrap: wrap;
+        }
+        .test-header-icon {
+            font-size: 3rem;
+            margin-right: 20px;
+            color: var(--text);
+        }
+        .test-header-text {
+            font-size: 3rem;
+            line-height: 3rem;
+            color: var(--text);
+        }
+        @media(max-width: 768px) {
+            .title-container {
+                display: flex;
+                width: 100%;
+                justify-content: center;
+            }
+            .install-button-container {
+                width: 100%;
+                text-align: center;
+            }
+            .install-button-container .btn {
+                width: 275px;
+                margin-top: 20px;
+            }
         }
     </style>
 <?php
@@ -86,19 +137,66 @@ $tool = $registrations[$install];
 
 $title = $tool['name'];
 $text = $tool['description'];
+$ltiurl = $tool['url'];
 $fa_icon = isset($tool['FontAwesome']) ? $tool['FontAwesome'] : false;
 $icon = false;
 if ( $fa_icon !== false ) {
     $icon = $CFG->fontawesome.'/png/'.str_replace('fa-','',$fa_icon).'.png';
 }
 
-if ( $fa_icon ) {
-    echo('<span class="hidden-xs fa '.$fa_icon.' fa-3x" style="color: var(--primary); float:right; margin: 2px"></span>');
-}
-echo('<center>');
-echo("<b>".htmlent_utf8($title)."</b>\n");
-echo("</center>\n");
 ?>
+    <!-- Install modal -->
+    <div id="<?=urlencode($install)?>_modal" class="modal fade" role="dialog">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal"><span class="fa fa-times" aria-hidden="true"></span><span class="sr-only">Cancel</span></button>
+                    <h4 class="modal-title">Install Learning App</h4>
+                </div>
+                <div class="modal-body">
+                    <form method="get" action="../index.php">
+                        <input type="hidden" name="install" value="<?=urlencode($install)?>">
+                        <div class="form-group">
+                            <label>Title</label>
+                            <input type="text" class="form-control" name="title" value="<?=htmlent_utf8($title)?>">
+                        </div>
+                        <div class="form-group">
+                            <label>Description</label>
+                            <textarea class="form-control" rows="5" name="description"><?=htmlent_utf8($text)?></textarea>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Submit</button>
+                        <button type="button" class="btn btn-link" data-dismiss="modal">Cancel</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- Banner/Header section -->
+    <div class="header-back-nav">
+        <ol class="breadcrumb">
+            <li><a href="../index.php">Store</a></li>
+            <li><a href="<?= $rest_path->parent ?>/details/<?= urlencode($install) ?>"><?= $title; ?></a></li>
+            <li class="active">Try It</li>
+        </ol>
+    </div>
+    <div class="test-header">
+    <div class="title-container">
+        <?php
+        if ( $fa_icon ) {
+            ?>
+            <span class="fa <?= $fa_icon; ?> test-header-icon"></span>
+            <?php
+        }
+        ?>
+        <span class="test-header-text"><?= htmlent_utf8($title); ?></span>
+    </div>
+    <div class="install-button-container">
+    <?php
+        echo('<button type="button" class="btn btn-success" role="button" data-toggle="modal" data-target="#'.urlencode($install).'_modal"><span class="fa fa-plus" aria-hidden="true"></span> Install</button>');
+    ?>
+    </div>
+</div>
+<div class="content-container container-fluid">
     <ul class="nav nav-tabs">
         <li class="active"><a href="#test" onclick="console.log('yada');" data-toggle="tab" aria-expanded="true">Test</a></li>
         <li><a href="#identity" data-toggle="tab" aria-expanded="false">
@@ -110,8 +208,6 @@ echo("</center>\n");
         </li>
         <!-- <li><a href="#grades" data-toggle="tab" aria-expanded="false">Grades</a></li> -->
         <li><a href="#debug" data-toggle="tab" aria-expanded="false">Debug</a></li>
-        <li class="hidden-xs"><a href="<?= $rest_path->parent ?>/details/<?= urlencode($install) ?>" role="button">Back to Details</a></li>
-        <li class="visible-xs"><a href="<?= $rest_path->parent ?>/details/<?= urlencode($install) ?>" role="button">Details</a></li>
     </ul>
     <div id="myTabContent" class="tab-content" style="margin-top:10px;">
         <div class="tab-pane fade" id="identity">
@@ -164,7 +260,7 @@ echo("</center>\n");
             ?>
         </div>
         <div class="tab-pane fade" id="debug">
-    <pre>
+    <pre class="debug-output">
     Launch Parameters:
         <?php print_r($parms) ?>
         <hr/>
@@ -176,6 +272,7 @@ echo("</center>\n");
     </pre>
         </div>
     </div>
+</div>
 <?php
 echo("<!-- \n");print_r($tool);echo("\n-->\n");
 $OUTPUT->footer();

--- a/store/details.php
+++ b/store/details.php
@@ -31,9 +31,139 @@ $OUTPUT->header();
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 9999;
+  z-index: 10000;
   display: none;
   background-color: rgba(0,0,0,0.5); /*dim the background*/
+  justify-content: center;
+  align-items: center;
+}
+#overlay_img {
+    max-width: 90%;
+}
+.slider-thumbnail {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    background-color: var(--background-focus);
+}
+.detail-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 2rem;
+    background-color: var(--background-focus);
+    border-bottom: 8px solid var(--secondary);
+    flex-wrap: wrap;
+}
+.detail-header-icon {
+    font-size: 3rem;
+    margin-right: 20px;
+    color: var(--text);
+}
+.detail-header-text {
+    font-size: 3rem;
+    line-height: 3rem;
+    color: var(--text);
+}
+@media(max-width: 768px) {
+    .title-container {
+        display: flex;
+        width: 100%;
+        justify-content: center;
+    }
+    .install-button-container {
+        width: 100%;
+        text-align: center;
+    }
+    .install-button-container .btn {
+        width: 275px;
+        margin-top: 20px;
+    }
+}
+.breadcrumb {
+    background-color: var(--background-color);
+    margin-bottom: 5px;
+    padding: 5px 15px;
+}
+.breadcrumb>.active {
+    color: var(--text-light);
+}
+.summary-text {
+    margin-bottom: 40px;
+    font-size: large;
+}
+.video-frame {
+    max-width: 100%;
+}
+.content-container {
+    display: flex;
+    padding: 20px;
+    padding-top: 40px;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    gap: 20px;
+}
+.summary-column {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 600px;
+    justify-content: flex-start;
+}
+.details-column {
+    width: 275px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+}
+.details-column input {
+    margin-bottom: 20px;
+}
+.button-container {
+    display: flex;
+    justify-content: center;
+}
+.button-container input {
+    width: 100%;
+}
+.tool-link-container {
+    padding: 8px 0;
+}
+.sidebar-header {
+    font-size: large;
+}
+a.tool-url-link {
+    text-decoration: none;
+    padding: 0;
+}
+a.tool-url-link:hover, a.tool-url-link:focus, a.tool-url-link:active {
+    color: var(--text-light);
+    text-decoration: none;
+}
+.bx-wrapper .bx-viewport {
+    background-color: var(--background-focus);
+    border-width: 2px;
+    border-color: var(--secondary);
+    box-shadow: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+}
+.bxslider {
+    display: flex;
+    align-items: center;
+    height: 315px;
+    width: 560px;
+}
+.bx-pager-item {
+    line-height: normal;
+}
+body .bx-wrapper .bx-pager.bx-default-pager a {
+    border: 1px solid var(--text);
+}
+.not-found-text {
+    margin: 40px;
+    font-size: 20px;
+    text-align: center;
 }
 </style>
 <?php
@@ -43,11 +173,64 @@ $registrations = findAllRegistrations(false, true);
 // echo("<pre>\n");var_dump($registrations);echo("</pre>");die();
 if ( count($registrations) < 1 ) $registrations = false;
 
+$rest_path = U::rest_path();
+$install = $rest_path->extra;
+$title = '';
+$fa_icon = 'fa-question';
+if (isset($registrations[$install])) {
+    $tool = $registrations[$install];
+    
+    $screen_shots = U::get($tool, 'screen_shots');
+    $video = U::get($tool, 'video');
+    if ( !is_array($screen_shots) || count($screen_shots) < 1 ) $screen_shots = false;
+    
+    $title = $tool['name'];
+    $text = $tool['description'];
+    $keywords = U::get($tool,'keywords');
+    $ltiurl = $tool['url'];
+    $fa_icon = isset($tool['FontAwesome']) ? $tool['FontAwesome'] : false;
+    $icon = false;
+    if ( $fa_icon !== false ) {
+        $icon = $CFG->fontawesome.'/png/'.str_replace('fa-','',$fa_icon).'.png';
+    }
+}
+
+?>
+<div class="header-back-nav">
+    <ol class="breadcrumb">
+    <li><a href="<?= $rest_path->parent; ?>">Store</a></li>
+    <li class="active"><?= $title ?></li>
+    </ol>
+</div>
+<div class="detail-header">
+    <div class="title-container">
+        <?php
+        if ( $fa_icon ) {
+            ?>
+            <span class="fa <?= $fa_icon; ?> detail-header-icon"></span>
+            <?php
+        }
+        ?>
+        <span class="detail-header-text"><?= htmlent_utf8($title); ?></span>
+    </div>
+    <div class="install-button-container">
+    <?php
+    if ( isset($_SESSION['gc_count']) ) {
+        echo('<a class="btn btn-success" href="'.$CFG->wwwroot.'/gclass/assign?lti='.urlencode($ltiurl).'&title='.urlencode($tool['name']));
+        echo('" title="Install in Classroom" target="iframe-frame"'."\n");
+        echo("onclick=\"showModalIframe(this.title, 'iframe-dialog', 'iframe-frame', _TSUGI.spinnerUrl, true);\" >\n");
+        echo('<span class="fa fa-plus"></span> Install</a>'."\n");
+    }
+    ?>
+    </div>
+</div>
+<?php
+
 $OUTPUT->bodyStart();
 ?>
-<div id="overlay" class="overlay" style="text-align: center;"
+<div id="overlay" class="overlay"
    onclick="document.getElementById('overlay').style.display = 'none';" >
-<img id="overlay_img" style="width:90%;margin-top: 50px;" src="<?= $OUTPUT->getSpinnerUrl(); ?>">
+<img id="overlay_img" src="<?= $OUTPUT->getSpinnerUrl(); ?>">
 </div>
 <?php
 $OUTPUT->topNav();
@@ -59,27 +242,11 @@ if ( ! ( $registrations ) ) {
     return;
 }
 
-$rest_path = U::rest_path();
-$install = $rest_path->extra;
 
 if ( ! isset($registrations[$install])) {
-    echo("<p>Tool registration for ".htmlentities($install)." not found</p>\n");
+    echo("<p class=\"not-found-text\">Tool registration for ".htmlentities($install)." not found</p>\n");
     $OUTPUT->footer();
     return;
-}
-$tool = $registrations[$install];
-
-$screen_shots = U::get($tool, 'screen_shots');
-if ( !is_array($screen_shots) || count($screen_shots) < 1 ) $screen_shots = false;
-
-$title = $tool['name'];
-$text = $tool['description'];
-$keywords = U::get($tool,'keywords');
-$ltiurl = $tool['url'];
-$fa_icon = isset($tool['FontAwesome']) ? $tool['FontAwesome'] : false;
-$icon = false;
-if ( $fa_icon !== false ) {
-    $icon = $CFG->fontawesome.'/png/'.str_replace('fa-','',$fa_icon).'.png';
 }
 
 // Check if the tsugi.php is upgraded for this tool
@@ -114,46 +281,102 @@ $register_good = $json_obj && isset($json_obj->name);
     <p>App Store Canvas Configuration URL<br/>
     <a href="<?= $CFG->wwwroot ?>/lti/store/canvas-config.xml" target="_blank"><?= $CFG->wwwroot ?>/lti/store/canvas-config.xml</a></p>
 </div>
-<?php
 
-if ( $fa_icon ) {
-    echo('<span class="hidden-xs fa '.$fa_icon.' fa-2x" style="color: var(--primary); float:right; margin: 2px"></span>');
-}
-echo("<h1>".htmlent_utf8($title)."</h1>\n");
-echo('<p class="hidden-xs">'.htmlent_utf8($text)."</p>\n");
-if (is_array($keywords)) {
-    sort($keywords);
-    echo('<p class="keywords">Tags: <span class="keyword-span">'.implode(", ", $keywords).'</span></p>');
-}
-if ( $screen_shots ) {
-    echo('<div class="row">'."\n");
-    echo('<div class="col-sm-4">'."\n");
-}
+<div class="content-container">
+    <div class="summary-column">
+        <span class="summary-text"> <?= htmlent_utf8($text); ?></span>
+        <?php
+        if ($video || $screen_shots) {
+            ?>
+            <div class="bxslider">
+                <?php
+                
+                if (is_string($video)) { ?>
+                    <iframe class="video-frame" height="315" width="560" src="<?= $video; ?>" frameborder="0" scrolling="0" allow="autoplay *; encrypted-media *; fullscreen *; picture-in-picture *;" allowfullscreen></iframe>
+                    <?php
+                }
+                if ($screen_shots) {
+                    foreach($screen_shots as $idx=>$screen_shot ) { ?>
+                        <div class="slider-thumbnail" id="slider-thumbnail-<?= $idx; ?>"><img src="<?= $screen_shot; ?>" title="<?= htmlentities($title); ?>"></div>
+                        <?php
+                    } 
+                }
+            ?>
+            </div>
+        <?php
+        }
+        ?>
+    </div>
+    <div class="details-column">
+        <?php
+            
+            echo('<form method="POST" style="display:inline" action="'.$rest_path->parent.'/test/'.urlencode($install).'">');
+            echo('<div class="button-container">');
+            echo('<input type="submit" class="btn btn-primary" value="Try It"></form> ');
+            echo('</div>');
+            if ( is_array(U::get($tool, 'languages')) ) {
+                ?>
+                <div class="tool-link-container">
+                    <div class="sidebar-header">Languages</div>
+                    <?php
+                    $first = true;
+                    foreach(U::get($tool, 'languages') as $language) {
+                        if ( ! $first ) echo(', ');
+                        $first = false;
+                        echo(htmlentities($language));
+                    }
+                    ?>
+                </div>
+                <?php
+            }
+            if ( is_string(U::get($tool, 'license')) ) {
+                ?>
+                <div class="tool-link-container">
+                    <div class="sidebar-header">License</div>
+                    <?php
+                        echo(htmlentities(U::get($tool, 'license')));
+                    ?>
+                </div>
+                <?php
+            }
+            $source_url = U::get($tool, 'source_url');
+            if ( is_string($source_url) ) {
+                ?>
+                <div class="tool-link-container">
+                    <a href="<?= $source_url; ?>" target="_blank" class="tool-url-link sidebar-header">Source Code <span class="fa fa-chevron-right"></span></a>
+                </div>
+                <?php
+            }
+            echo('<div class="tool-link-container">');
+            echo('<a href="#" class="tool-url-link sidebar-header" role="button" onclick="showModal(\'Tool URLs\',\'url-dialog\');">Tool URLs <span class="fa fa-chevron-right"></span></a>');
+            echo('</div>');
+
+            if (is_array($keywords)) {
+                sort($keywords);
+                ?>
+                <div class="tool-link-container">
+                    <div class="sidebar-header">Tags</div>
+                    <h3 style="margin-top: 0;">
+
+                    <?php
+                        foreach ($keywords as $tag) {
+                            ?>
+                                <span class="label label-default"><?= $tag; ?></span>
+                            <?php
+                        }
+                    ?>
+                    </h3>
+                </div>
+                <?php
+            }
+            ?>
+            <div class="tool-link-container">
+                <div class="sidebar-header">Additional Details</div>
+            </div>
+            <?php
 $script = isset($tool['script']) ? $tool['script'] : "index";
 $path = $tool['url'];
-
-
-echo('<form method="POST" style="display:inline" action="'.$rest_path->parent.'/test/'.urlencode($install).'">');
-echo('<a href="'.$rest_path->parent.'" class="btn btn-default" role="button">Back to Store</a>');
-echo(' ');
-if ( isset($_SESSION['gc_count']) ) {
-    echo('<a href="'.$CFG->wwwroot.'/gclass/assign?lti='.urlencode($ltiurl).'&title='.urlencode($tool['name']));
-    echo('" title="Install in Classroom" target="iframe-frame"'."\n");
-    echo("onclick=\"showModalIframe(this.title, 'iframe-dialog', 'iframe-frame', _TSUGI.spinnerUrl, true);\" >\n");
-    echo('<img height=32 width=32 src="https://www.gstatic.com/classroom/logo_square_48.svg"></a>'."\n");
-}
-echo(' ');
-echo('<a href="#" class="btn btn-default" role="button" onclick="showModal(\'Tool URLs\',\'url-dialog\');">Tool URLs</a>');
-echo(' ');
-echo('<input type="submit" class="btn btn-default" value="Test"></form> ');
-echo("\n");
-
 echo("<p><ul>\n");
-$video = U::get($tool, 'video');
-if ( is_string($video) ) {
-    echo('<li><p><a href="'.$video.'"
-       target="_blank">'._m('Video Demonstration').'</a></p></li>'."\n");
-}
 if ( isset($CFG->privacy_url) ) {
     echo('<li><p><a href="'.$CFG->privacy_url.'"
        target="_blank">'._m('Privacy Policy').'</a></p></li>'."\n");
@@ -193,32 +416,9 @@ if ( $CFG->launchactivity ) {
     echo(_m('Can send analytics to learning record store.'));
     echo("</p></li>\n");
 }
-if ( is_array(U::get($tool, 'languages')) ) {
-    echo('<li><p>');
-    echo(_m('Languages:'));
-    echo(' ');
-    $first = true;
-    foreach(U::get($tool, 'languages') as $language) {
-        if ( ! $first ) echo(', ');
-        $first = false;
-        echo(htmlentities($language));
-    }
-    echo("</p></li>\n");
-}
 if ( isset($CFG->sla_url) ) {
     echo('<li><p><a href="'.$CFG->sla_url.'"
        target="_blank">'._m('Service Level Agreement').'</a></p></li>'."\n");
-}
-if ( is_string(U::get($tool, 'license')) ) {
-    echo('<li><p>');
-    echo(_m('License:'));
-    echo(' ');
-    echo(htmlentities(U::get($tool, 'license')));
-}
-$source_url = U::get($tool, 'source_url');
-if ( is_string($source_url) ) {
-    echo('<li><p><a href="'.$source_url.'"
-       target="_blank">'._m('Source code').'</a></p></li>'."\n");
 }
 
 if ( isset($CFG->google_classroom_secret) ) {
@@ -248,20 +448,8 @@ echo("</p></li>\n");
 
 
 echo("</ul>\n");
-
-if ( $screen_shots ) {
-    echo("<!-- .col-sm-4--></div>\n");
-    echo('<div class="col-sm-8">'."\n");
-    echo("<center>\n");
-    echo('<div class="bxslider">');
-    foreach($screen_shots as $screen_shot ) {
-       echo('<div><img title="'.htmlentities($title).'" onclick="$(\'#overlay_img\').attr(\'src\',this.src);document.getElementById(\'overlay\').style.display = \'block\';"');
-       echo(' src="'.$screen_shot.'"></div>'."\n");
-    }
-    echo("</center>\n");
-    echo("<!-- .col-sm-8--></div>\n");
-    echo("</div>\n");
-}
+echo("</div>\n");
+echo("</div>\n");
 
 echo("<!-- \n");print_r($tool);echo("\n-->\n");
 $OUTPUT->footerStart();
@@ -273,10 +461,23 @@ $(document).ready(function() {
     $('.bxslider').bxSlider({
         useCSS: false,
         adaptiveHeight: false,
-        slideWidth: "240px",
+        // slideWidth: "240px",
         infiniteLoop: false,
-        maxSlides: 3
+        // maxSlides: 3
     });
+
+    <?php
+    if ($screen_shots) {
+        foreach($screen_shots as $idx=>$screen_shot) {
+            ?>
+            $('#slider-thumbnail-<?= $idx; ?>').click(function () {
+                $('#overlay_img').attr('src', "<?= $screen_shot; ?>");
+                document.getElementById('overlay').style.display = 'flex';
+            });
+            <?php
+        }
+    }
+    ?>
 });
 </script>
 <?php

--- a/store/test.php
+++ b/store/test.php
@@ -35,6 +35,51 @@ $OUTPUT->header();
 #XbasicltiDebugToggle {
     display: none;
 }
+#body_container {
+    padding-top: 40px;
+}
+.breadcrumb {
+    background-color: var(--background-color);
+    margin-bottom: 5px;
+    padding: 5px 15px;
+}
+.breadcrumb>.active {
+    color: var(--text-light);
+}
+.test-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 2rem;
+    background-color: var(--background-focus);
+    border-bottom: 8px solid var(--secondary);
+    flex-wrap: wrap;
+}
+.test-header-icon {
+    font-size: 3rem;
+    margin-right: 20px;
+    color: var(--text);
+}
+.test-header-text {
+    font-size: 3rem;
+    line-height: 3rem;
+    color: var(--text);
+}
+@media(max-width: 768px) {
+    .title-container {
+        display: flex;
+        width: 100%;
+        justify-content: center;
+    }
+    .install-button-container {
+        width: 100%;
+        text-align: center;
+    }
+    .install-button-container .btn {
+        width: 275px;
+        margin-top: 20px;
+    }
+}
 </style>
 <?php
 
@@ -64,6 +109,51 @@ if ( $secret === false ) {
     return;
 }
 
+$rest_path = U::rest_path();
+$install = $rest_path->extra;
+
+if ($registrations && isset($registrations[$install])) {
+    $tool = $registrations[$install];
+    $ltiurl = $tool['url'];
+    $text = $tool['description'];
+    $title = $tool['name'];
+    $fa_icon = isset($tool['FontAwesome']) ? $tool['FontAwesome'] : false;
+    $icon = false;
+    if ( $fa_icon !== false ) {
+        $icon = $CFG->fontawesome.'/png/'.str_replace('fa-','',$fa_icon).'.png';
+    }
+?>
+    <div class="header-back-nav">
+        <ol class="breadcrumb">
+            <li><a href="<?= $rest_path->parent; ?>">Store</a></li>
+            <li><a href="<?= $rest_path->parent ?>/details/<?= urlencode($install) ?>"><?= $title; ?></a></li>
+            <li class="active">Try It</li>
+        </ol>
+    </div>
+    <div class="test-header">
+    <div class="title-container">
+        <?php
+        if ( $fa_icon ) {
+            ?>
+            <span class="fa <?= $fa_icon; ?> test-header-icon"></span>
+            <?php
+        }
+        ?>
+        <span class="test-header-text"><?= htmlent_utf8($title); ?></span>
+    </div>
+    <div class="install-button-container">
+    <?php
+    if ( isset($_SESSION['gc_count']) ) {
+        echo('<a class="btn btn-success" href="'.$CFG->wwwroot.'/gclass/assign?lti='.urlencode($ltiurl).'&title='.urlencode($tool['name']));
+        echo('" title="Install in Classroom" target="iframe-frame"'."\n");
+        echo("onclick=\"showModalIframe(this.title, 'iframe-dialog', 'iframe-frame', _TSUGI.spinnerUrl, true);\" >\n");
+        echo('<span class="fa fa-plus"></span> Install</a>'."\n");
+    }
+    ?>
+    </div>
+</div>
+<?php
+}
 
 $OUTPUT->bodyStart();
 $OUTPUT->topNav();
@@ -75,30 +165,12 @@ if ( ! ( $registrations ) ) {
     return;
 }
 
-$rest_path = U::rest_path();
-$install = $rest_path->extra;
+if ( ! isset($registrations[$install])) {
+    echo("<p>Tool registration for ".htmlentities($install)." not found</p>\n");
+    $OUTPUT->footer();
+    return;
+}
 
-    if ( ! isset($registrations[$install])) {
-        echo("<p>Tool registration for ".htmlentities($install)." not found</p>\n");
-        $OUTPUT->footer();
-        return;
-    }
-    $tool = $registrations[$install];
-
-    $title = $tool['name'];
-    $text = $tool['description'];
-    $fa_icon = isset($tool['FontAwesome']) ? $tool['FontAwesome'] : false;
-    $icon = false;
-    if ( $fa_icon !== false ) {
-        $icon = $CFG->fontawesome.'/png/'.str_replace('fa-','',$fa_icon).'.png';
-    }
-
-    if ( $fa_icon ) {
-        echo('<span class="hidden-xs fa '.$fa_icon.' fa-3x" style="color: var(--primary); float:right; margin: 2px"></span>');
-    }
-    echo('<center>');
-    echo("<h1>".htmlent_utf8($title)."</h1>\n");
-    echo("</center>\n");
 ?>
 <ul class="nav nav-tabs">
   <li class="active"><a href="#test" onclick="console.log('yada');" data-toggle="tab" aria-expanded="true">Test</a></li>
@@ -111,8 +183,6 @@ $install = $rest_path->extra;
       </li>
   <!-- <li><a href="#grades" data-toggle="tab" aria-expanded="false">Grades</a></li> -->
   <li><a href="#debug" data-toggle="tab" aria-expanded="false">Debug</a></li>
-  <li class="hidden-xs"><a href="<?= $rest_path->parent ?>/details/<?= urlencode($install) ?>" role="button">Back to Details</a></li>
-  <li class="visible-xs"><a href="<?= $rest_path->parent ?>/details/<?= urlencode($install) ?>" role="button">Details</a></li>
 </ul>
 <div id="myTabContent" class="tab-content" style="margin-top:10px;">
   <div class="tab-pane fade" id="identity">
@@ -169,7 +239,7 @@ print($content);
 ?>
   </div>
   <div class="tab-pane fade" id="debug">
-    <pre>
+    <pre class="debug-output">
     Launch Parameters:
     <?php print_r($parms) ?>
     <hr/>


### PR DESCRIPTION
One more PR in case it is useful!

This one is for updating the store UI, and it isn't terrible as-is, but it is better with the changes in [the PR I submitted for tsugi-static](https://github.com/tsugiproject/tsugi-static/pull/8). It should also work with the [dark mode PR](https://github.com/tsugiproject/tsugi/pull/156).

Main store page:
- A featured slideshow at the top of the store tied to register.php tool_phase = "new"
- New layout for the tool cards in the store main page
- The filter in the store page filters by tool name

Tool details page:
- Layout rearrangements and styling changes
- Breadcrumb at top leading back to the store

Tool test page:
- Minor styling changes
- Breadcrumbs at the top leading back to the tool details and store

![image](https://user-images.githubusercontent.com/6700647/224164850-61df428b-90c7-452c-b39e-5ef4833d859b.png)

![image](https://user-images.githubusercontent.com/6700647/224165003-f171101f-4614-435a-a576-faae96f91b8c.png)

![image](https://user-images.githubusercontent.com/6700647/224165101-8a2f3585-7b58-4410-bad2-0fa0664c327b.png)

![image](https://user-images.githubusercontent.com/6700647/224166256-bbc24cf1-ead8-4a3a-a668-753a6d36daff.png)

![image](https://user-images.githubusercontent.com/6700647/224166490-8c0b8308-7547-4c11-a7d1-93a4e6e7f802.png)

![image](https://user-images.githubusercontent.com/6700647/224166538-3321345e-027b-4cd6-87b2-850275a495ab.png)
