### PR TITLE
Fix two issues:

### DIFF
--- a/admin/key/keys.php
+++ b/admin/key/keys.php
@@ -39,7 +39,7 @@ foreach ( $rows as $row ) {
     $newrow = array();
     $newrow['key_id'] = $row['key_id'];
     $newrow['key'] = $row['key_key'];
-    if ( strlen($row['key_title']) > 0 ) $newrow['key'] = $row['key_title'];
+    if ( !empty($row['key_title']) ) $newrow['key'] = $row['key_title'];
     $key_type = '';
     if ( is_string($row['key_key']) && strlen($row['key_key']) > 1 && is_string($row['secret']) && strlen($row['secret']) > 0 ) {
         $key_type .= 'LTI 1.1';
@@ -54,8 +54,8 @@ foreach ( $rows as $row ) {
     if ( $key_type == '' ) $key_type = 'Draft';
     $newrow['key_type'] = $key_type;
     $issuer_key = $row['lms_issuer'];
-    if ( strlen($row['issuer_key']) > 0 ) $issuer_key = "I: " . $row['issuer_key'];
-    if ( strlen($issuer_key) > 0 && strlen($row['deploy_key']) > 0 ) $issuer_key .= ' | ' . $row['deploy_key'];
+    if ( !empty($row['issuer_key']) ) $issuer_key = "I: " . $row['issuer_key'];
+    if ( !empty($issuer_key) && !empty($row['deploy_key']) ) $issuer_key .= ' | ' . $row['deploy_key'];
     $newrow['issuer_|_deployment'] = $issuer_key;
     $newrow['login_at'] = $row['login_at'];
     $newrow['updated_at'] = $row['updated_at'];

--- a/vendor/tsugi/lib/src/Config/ConfigInfo.php
+++ b/vendor/tsugi/lib/src/Config/ConfigInfo.php
@@ -14,6 +14,21 @@ namespace Tsugi\Config;
 class ConfigInfo {
 
     /**
+     * The slow_query setting indicated when we want PDOX to log a query for being too slow.
+     */
+    public $slow_query;
+
+    /**
+     * Defaults to $CFG->apphome if defined and $CFG->wwwroot if that is not defined or false
+     */
+    public $logout_return_url;
+
+    /**
+     * Indicate whether the PHP on this server wants to verify SSL or not
+     */
+    public $verifypeer;
+    
+    /**
      * Extensions
      */
     public $extensions;


### PR DESCRIPTION
There are two issues when updating php version to php 8.2.

1. The creation of dynamic properties:
- Error Message: 
  - Deprecated: Creation of dynamic property ```Tsugi\Config\ConfigInfo::$slow_query``` is deprecated
- Same error messages for ```$logout_return_url``` and ```$verifypeer```
- The solution is to add these fields to ```ConfigInfo.php```
- **NOTE**: I've included some basic comments while adding these fields in ```ConfigInfo```. Feel free to enhance them further if needed.

2. Passing null to ```strlen()```:
- Error Message:
  - Deprecated: strlen(): Passing null to parameter # 1 ($string) of type string is deprecated
- The solution is to use ```!empty()``` instead of ```strlen() > 0``` in the if statement.