### PR TITLE
Escape breadcrumb titles

### DIFF
--- a/lti/store/details.php
+++ b/lti/store/details.php
@@ -280,7 +280,7 @@ $register_good = $json_obj && isset($json_obj->name);
     <div class="header-back-nav">
         <ol class="breadcrumb">
         <li><a href="../index.php">Store</a></li>
-        <li class="active"><?= $title ?></li>
+        <li class="active"><?= htmlent_utf8($title) ?></li>
         </ol>
     </div>
     <div class="detail-header">

--- a/lti/store/test.php
+++ b/lti/store/test.php
@@ -176,7 +176,7 @@ if ( $fa_icon !== false ) {
     <div class="header-back-nav">
         <ol class="breadcrumb">
             <li><a href="../index.php">Store</a></li>
-            <li><a href="<?= $rest_path->parent ?>/details/<?= urlencode($install) ?>"><?= $title; ?></a></li>
+            <li><a href="<?= $rest_path->parent ?>/details/<?= urlencode($install) ?>"><?= htmlent_utf8($title); ?></a></li>
             <li class="active">Try It</li>
         </ol>
     </div>

--- a/store/details.php
+++ b/store/details.php
@@ -198,7 +198,7 @@ if (isset($registrations[$install])) {
 <div class="header-back-nav">
     <ol class="breadcrumb">
     <li><a href="<?= $rest_path->parent; ?>">Store</a></li>
-    <li class="active"><?= $title ?></li>
+    <li class="active"><?= htmlent_utf8($title) ?></li>
     </ol>
 </div>
 <div class="detail-header">

--- a/store/test.php
+++ b/store/test.php
@@ -127,7 +127,7 @@ if ($registrations && isset($registrations[$install])) {
     <div class="header-back-nav">
         <ol class="breadcrumb">
             <li><a href="<?= $rest_path->parent; ?>">Store</a></li>
-            <li><a href="<?= $rest_path->parent ?>/details/<?= urlencode($install) ?>"><?= $title; ?></a></li>
+            <li><a href="<?= $rest_path->parent ?>/details/<?= urlencode($install) ?>"><?= htmlent_utf8($title); ?></a></li>
             <li class="active">Try It</li>
         </ol>
     </div>


### PR DESCRIPTION
Titles containing non-alphanumeric characters can break the layout or formatting when rendered in breadcrumbs. Escaping them on output with html entities fixes this for existing and future titles.