### PR TITLE
Refresh session lifetime

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -5,6 +5,7 @@ use \Tsugi\Util\U;
 if ( ! defined('COOKIE_SESSION') ) define('COOKIE_SESSION', true);
 require_once("../config.php");
 session_start();
+session_regenerate_id(true);
 require_once("gate.php");
 if ( $REDIRECTED === true || ! isset($_SESSION["admin"]) ) return;
 

--- a/login.php
+++ b/login.php
@@ -25,6 +25,7 @@ function login_redirect($path=false) {
 $PDOX = LTIX::getConnection();
 
 session_start();
+session_regenerate_id(true);
 error_log('Session in login '.session_id());
 
 $oauth_consumer_key = 'google.com';


### PR DESCRIPTION
Stale session ids can cause premature session expiration after login. Regenerating the session id provides the expected session lifetime, and is also considered best practice for session management.