### PR TITLE
Harden secure login cookie

### DIFF
--- a/lib/src/Crypt/SecureCookie.php
+++ b/lib/src/Crypt/SecureCookie.php
@@ -16,10 +16,7 @@ class SecureCookie {
 
     public static function decrypt($cipher) {
         global $CFG;
-        // TODO: Use AesOpenSSL after time passes from March 1, 2022
-        // $plain = \Tsugi\Crypt\AesOpenSSL::decrypt($cipher, $CFG->cookiesecret) ;
-        $plain = \Tsugi\Crypt\AesCtr::decrypt($cipher, $CFG->cookiesecret, 256) ;
-        return $plain;
+        return \Tsugi\Crypt\AesOpenSSL::decrypt($cipher, $CFG->cookiesecret);
     }
 
     public static function create($id,$guid,$context_id,$debug=false) {
@@ -33,6 +30,7 @@ class SecureCookie {
     public static function extract($encr,$debug=false) {
         global $CFG;
         $pt = self::decrypt($encr);
+        if ( ! is_string($pt) ) return false;
         if ( $debug ) echo("PT2: $pt\n");
         $pieces = explode('::',$pt);
         if ( count($pieces) != 4 ) return false;
@@ -40,11 +38,21 @@ class SecureCookie {
         return Array($pieces[1], $pieces[2], $pieces[3]);
     }
 
+    public static function cookieOptions($expires) {
+        return array(
+            'expires' => $expires,
+            'path' => '/',
+            'secure' => true,
+            'httponly' => true,
+            'samesite' => 'None',
+        );
+    }
+
     // We also session_unset - because something is not right
     // See: http://php.net/manual/en/function.setcookie.php
     public static function delete() {
         global $CFG;
-        setcookie($CFG->cookiename,'',time() - 100, '/'); // Expire 100 seconds ago
+        setcookie($CFG->cookiename, '', self::cookieOptions(time() - 100)); // Expire 100 seconds ago
         session_unset();
     }
 
@@ -52,6 +60,6 @@ class SecureCookie {
     public static function set($user_id, $userEmail, $context_id) {
         global $CFG;
         $ct = self::create($user_id,$userEmail, $context_id);
-        setcookie($CFG->cookiename,$ct,time() + (86400 * 45), '/'); // 86400 = 1 day
+        setcookie($CFG->cookiename, $ct, self::cookieOptions(time() + (86400 * 45))); // 86400 = 1 day
     }
 }

--- a/lib/tests/Crypt/SecureCookieTest.php
+++ b/lib/tests/Crypt/SecureCookieTest.php
@@ -3,6 +3,8 @@
 use \Tsugi\Crypt\SecureCookie;
 
 require_once('src/Crypt/AesOpenSSL.php');
+require_once('src/Crypt/Aes.php');
+require_once('src/Crypt/AesCtr.php');
 require_once('src/Crypt/SecureCookie.php');
 require_once "src/Config/ConfigInfo.php";
 
@@ -36,6 +38,28 @@ class SecureCookieTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($pieces[0], $id);
         $this->assertEquals($pieces[1], $guid);
         $this->assertEquals($pieces[2], $cid);
+    }
+
+    public function testSecureCookieOptions() {
+        $expires = time() + 1000;
+        $options = SecureCookie::cookieOptions($expires);
+
+        $this->assertEquals($expires, $options['expires']);
+        $this->assertEquals('/', $options['path']);
+        $this->assertTrue($options['secure']);
+        $this->assertTrue($options['httponly']);
+        $this->assertEquals('None', $options['samesite']);
+    }
+
+    public function testSecureCookieRejectsLegacyCiphertext() {
+        global $CFG;
+        $CFG = new \Tsugi\Config\ConfigInfo(basename(__FILE__),'http://localhost');
+        $CFG->cookiepad = 'Helloworld';
+        $CFG->cookiesecret = '0123456789abcdef0123456789abcdef';
+
+        $legacy = \Tsugi\Crypt\AesCtr::legacyEncrypt('Helloworld::1::xyzzy::999', $CFG->cookiesecret, 256);
+        $pieces = SecureCookie::extract($legacy, false);
+        $this->assertFalse($pieces);
     }
 
 }


### PR DESCRIPTION
## Summary
- harden the long-lived secure login cookie with explicit `Secure`, `HttpOnly`, and `SameSite=None` attributes
- stop accepting legacy `AesCtr` ciphertext in the secure-cookie path and use `AesOpenSSL` directly
- add targeted secure-cookie tests for the cookie options and legacy-ciphertext rejection

## Notes
- this intentionally limits the crypto cleanup to the secure-cookie flow
- `AesCtr` is still used elsewhere in the codebase, including badges, RPC, and other legacy-secret paths, so it was not deleted in this PR
- existing remember-me cookies created with the old secure-cookie format will no longer be accepted and will require a fresh login

## Validation
- `php -l lib/src/Crypt/SecureCookie.php`
- `php -l lib/tests/Crypt/SecureCookieTest.php`
- custom PHP smoke test covering create/extract, cookie options, and legacy secure-cookie rejection
