### PR TITLE
Look up HTTP headers case-insensitively

### DIFF
--- a/lib/src/Util/LTI.php
+++ b/lib/src/Util/LTI.php
@@ -365,18 +365,13 @@ class LTI {
     public static function getAuthorizationHeader()
     {
         $request_headers = OAuthUtil::get_headers();
-        $auth = isset($request_headers['Authorization']) ? $request_headers['Authorization'] : null;
-        if ( ! $auth ) $auth = isset($request_headers['authorization']) ? $request_headers['authorization'] : null;
-        return $auth;
+        return U::getIgnoreCase($request_headers, 'Authorization', null);
     }
 
     public static function getContentTypeHeader()
     {
         $request_headers = OAuthUtil::get_headers();
-        $ctype = isset($request_headers['Content-Type']) ? $request_headers['Content-Type'] : null;
-        if ( ! $ctype ) $ctype = isset($request_headers['Content-type']) ? $request_headers['Content-type'] : null;
-        if ( ! $ctype ) $ctype = isset($request_headers['content-type']) ? $request_headers['content-type'] : null;
-        return $ctype;
+        return U::getIgnoreCase($request_headers, 'Content-Type', null);
     }
 
     public static function getOAuthKeyFromHeaders()

--- a/lib/src/Util/LTI13.php
+++ b/lib/src/Util/LTI13.php
@@ -557,7 +557,7 @@ class LTI13 {
             if (is_array($debug_log) ) $debug_log[] = $response_headers;
 
             $nextUrl = null;
-            $link_header = U::get($response_headers, 'Link', null);
+            $link_header = U::getIgnoreCase($response_headers, 'Link', null);
             if ( is_string($link_header) ) {
                 if ( is_array($debug_log) ) $debug_log[] = 'Link header: ' . $link_header;
                 $linkHeader = LinkHeader::fromString($link_header);
@@ -658,7 +658,7 @@ class LTI13 {
             if (is_array($debug_log) ) $debug_log[] = $response_headers;
 
             $nextUrl = null;
-            $link_header = U::get($response_headers, 'Link', null);
+            $link_header = U::getIgnoreCase($response_headers, 'Link', null);
             if ( is_string($link_header) ) {
                 if ( is_array($debug_log) ) $debug_log[] = 'Link header: ' . $link_header;
                 $linkHeader = LinkHeader::fromString($link_header);

--- a/lib/src/Util/Net.php
+++ b/lib/src/Util/Net.php
@@ -91,7 +91,7 @@ class Net {
     /**
      * Extract a set of header lines into an array
      *
-     * Takes a newline separated header sting and returns a key/value array.
+     * Takes a newline separated header string and returns a key/value array.
      * Keys are kept as received (HTTP/2 and HTTP/3 send them lowercase).
      * Header names are case-insensitive (RFC 7230 / RFC 9110), so look
      * them up with U::getIgnoreCase() rather than U::get().

--- a/lib/src/Util/Net.php
+++ b/lib/src/Util/Net.php
@@ -91,7 +91,10 @@ class Net {
     /**
      * Extract a set of header lines into an array
      *
-     * Takes a newline separated header sting and returns a key/value array
+     * Takes a newline separated header sting and returns a key/value array.
+     * Keys are kept as received (HTTP/2 and HTTP/3 send them lowercase).
+     * Header names are case-insensitive (RFC 7230 / RFC 9110), so look
+     * them up with U::getIgnoreCase() rather than U::get().
      */
     public static function parseHeaders($headerstr=false) {
         if ( $headerstr === false ) $headerstr = self::getLastHeadersReceived();

--- a/lib/src/Util/U.php
+++ b/lib/src/Util/U.php
@@ -95,6 +95,7 @@ class U {
     public static function getIgnoreCase($arr, $key, $default=null) {
         if ( !is_array($arr) ) return $default;
         if ( !isset($key) ) return $default;
+        if ( is_array($key) || is_object($key) ) return $default;
         if ( isset($arr[$key]) ) return $arr[$key];
         $keyLower = strtolower((string)$key);
         foreach ($arr as $k => $v) {

--- a/lib/src/Util/U.php
+++ b/lib/src/Util/U.php
@@ -85,6 +85,24 @@ class U {
         return $arr[$key];
     }
 
+    /**
+     * Like get(), but match array keys without regard to case.
+     *
+     * HTTP header names are case-insensitive (RFC 7230). HTTP/2 requires
+     * names to be lowercase, so LMS responses (e.g. Canvas) may use 'link'
+     * instead of 'Link'. Exact match is preferred when present.
+     */
+    public static function getIgnoreCase($arr, $key, $default=null) {
+        if ( !is_array($arr) ) return $default;
+        if ( !isset($key) ) return $default;
+        if ( isset($arr[$key]) ) return $arr[$key];
+        $keyLower = strtolower((string)$key);
+        foreach ($arr as $k => $v) {
+            if ( strtolower((string)$k) === $keyLower ) return $v;
+        }
+        return $default;
+    }
+
     public static function htmlpre_utf8($string) {
         return str_replace("<","&lt;",$string);
     }

--- a/lib/tests/Util/NetTest.php
+++ b/lib/tests/Util/NetTest.php
@@ -3,6 +3,7 @@
 require_once "src/Util/Net.php";
 
 use \Tsugi\Util\Net;
+use \Tsugi\Util\U;
 
 class NetTest extends \PHPUnit\Framework\TestCase
 {
@@ -72,6 +73,16 @@ class NetTest extends \PHPUnit\Framework\TestCase
         $existing = Net::ensureUserAgentHeader("User-Agent: Custom/1.0\r\nAccept: text/plain");
         $this->assertStringContainsString('User-Agent: Custom/1.0', $existing);
         $this->assertEquals(1, preg_match_all('/User-Agent:/i', $existing));
+    }
+
+    public function testParseHeadersIgnoreCase() {
+        // HTTP/2 lowercases header names (RFC 9113). parseHeaders() does not
+        // rewrite keys, so 'Link' is absent and getIgnoreCase() is required.
+        $raw = "HTTP/2 200\ncontent-type: application/vnd.ims.lti-nrps.v2.membershipcontainer+json\nlink: </api/lti/courses/1/names_and_roles?page=2>; rel=\"next\"\n\n";
+        $headers = Net::parseHeaders($raw);
+        $this->assertNull(U::get($headers, 'Link'));
+        $this->assertEquals('</api/lti/courses/1/names_and_roles?page=2>; rel="next"', U::getIgnoreCase($headers, 'Link'));
+        $this->assertEquals('application/vnd.ims.lti-nrps.v2.membershipcontainer+json', U::getIgnoreCase($headers, 'Content-Type'));
     }
 
 }

--- a/lib/tests/Util/UTest.php
+++ b/lib/tests/Util/UTest.php
@@ -386,4 +386,28 @@ class UTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    public function testGetIgnoreCase() {
+        // HTTP header field names are case-insensitive (RFC 7230 / RFC 9110).
+        // HTTP/2 and HTTP/3 require names to be lowercase on the wire, so
+        // servers like Canvas often return 'link' rather than 'Link'.
+        // parseHeaders() keeps the keys as received; callers must look them
+        // up with getIgnoreCase(), not get().
+        $headers = array('link' => '</members?page=2>; rel="next"', 'Content-Type' => 'application/json');
+
+        $this->assertEquals('application/json', U::getIgnoreCase($headers, 'Content-Type'));
+        $this->assertEquals('application/json', U::getIgnoreCase($headers, 'content-type'));
+        $this->assertEquals('</members?page=2>; rel="next"', U::getIgnoreCase($headers, 'Link'));
+        $this->assertEquals('</members?page=2>; rel="next"', U::getIgnoreCase($headers, 'link'));
+        $this->assertEquals('</members?page=2>; rel="next"', U::getIgnoreCase($headers, 'LINK'));
+
+        $this->assertNull(U::get($headers, 'Link'));
+        $this->assertEquals('missing', U::getIgnoreCase($headers, 'X-Not-There', 'missing'));
+        $this->assertEquals('missing', U::getIgnoreCase(null, 'Link', 'missing'));
+        $this->assertEquals('missing', U::getIgnoreCase($headers, null, 'missing'));
+
+        $both = array('Link' => 'canonical', 'link' => 'lowercase');
+        $this->assertEquals('canonical', U::getIgnoreCase($both, 'Link'));
+        $this->assertEquals('lowercase', U::getIgnoreCase($both, 'link'));
+    }
+
 }

--- a/lib/tests/Util/UTest.php
+++ b/lib/tests/Util/UTest.php
@@ -404,6 +404,8 @@ class UTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('missing', U::getIgnoreCase($headers, 'X-Not-There', 'missing'));
         $this->assertEquals('missing', U::getIgnoreCase(null, 'Link', 'missing'));
         $this->assertEquals('missing', U::getIgnoreCase($headers, null, 'missing'));
+        $this->assertEquals('missing', U::getIgnoreCase($headers, array('Link'), 'missing'));
+        $this->assertEquals('missing', U::getIgnoreCase($headers, new \stdClass(), 'missing'));
 
         $both = array('Link' => 'canonical', 'link' => 'lowercase');
         $this->assertEquals('canonical', U::getIgnoreCase($both, 'Link'));


### PR DESCRIPTION
## Summary
- Add `U::getIgnoreCase()` for case-insensitive array key lookup (HTTP headers are case-insensitive; HTTP/2 sends them lowercase).
- Use it for the NRPS/groups `Link` header so Canvas paging works, and for `Authorization` / `Content-Type` header helpers.
- Tests cover lowercase `link` vs `Link` and document the RFC / HTTP/2 rules.

Reported by Tom Reijnders: Canvas returns `link` (lowercase), so `U::get($headers, 'Link')` missed the next-page URL.

## Test plan
- [ ] `composer test` in `lib/` (new `testGetIgnoreCase` and `testParseHeadersIgnoreCase`)
- [ ] Canvas NRPS roster with paging follows the `Link` header to the next page


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP header handling by recognizing header names regardless of capitalization.
  * Increased reliability when processing authorization, content type, link, and related headers.

* **Tests**
  * Added coverage for mixed-case and lowercase HTTP headers.
  * Verified default behavior for missing, null, and unmatched header values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->