### PR TITLE
Add a courses controller for nested /courses/{id} tool URLs.

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,7 @@
 <IfModule mod_rewrite.c>
     RewriteEngine on
+    # config.php has secrets; FileRouter would also map /config and /config-dist
+    RewriteRule ^config(-dist)?(\.php)?(/.*)?$ - [R=404,L,NS]
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_URI} !=/favicon.ico

--- a/config-dist.php
+++ b/config-dist.php
@@ -164,7 +164,8 @@ $CFG->adminpw = getenv('TSUGI_ADMIN_PW') ?: false;
 
 // Temporary menu-only flag: emit /courses/{id}/... from Courses::toolPathPrefix().
 // Controllers follow the request path and ignore this. Unset/false = off.
-// true = all logged-in users with a context; array = those emails only.
+// Prefix is Google-login only (LMS launches stay unprefixed).
+// true = Google-login users with a context; array = those emails only.
 // $CFG->setExtension('courses_in_urls', true);
 // $CFG->setExtension('courses_in_urls', array('you@example.com'));
 

--- a/config-dist.php
+++ b/config-dist.php
@@ -162,6 +162,12 @@ $CFG->adminpw = getenv('TSUGI_ADMIN_PW') ?: false;
 // the "local" students that log in through Google.
 // $CFG->context_title = "Web Applications for Everybody";
 
+// Temporary menu-only flag: emit /courses/{id}/... from Courses::toolPathPrefix().
+// Controllers follow the request path and ignore this. Unset/false = off.
+// true = all logged-in users with a context; array = those emails only.
+// $CFG->setExtension('courses_in_urls', true);
+// $CFG->setExtension('courses_in_urls', array('you@example.com'));
+
 // If we are going to use the lessons tool and/or badges, we need to
 // create and point to a lessons.json file
 // $CFG->lessons = $CFG->dirroot.'/../lessons.json';

--- a/docs/courses-urls.md
+++ b/docs/courses-urls.md
@@ -26,12 +26,16 @@ leaves the last nested request’s context in the session.
 
 ## Multiple tabs
 
-One PHP session, one `context_id`. PHP serializes requests on that
-session, so two submits do not run in true parallel.
+One PHP session, one stored `context_id`. File sessions lock, so requests
+for that session run one at a time. The supported memcached setup turns
+locking off (`memcached.sess_locking=0`), so two tabs **can** run at
+once. Last write wins, and that is fine.
 
-Each nested URL still switches to **its** `{id}` before doing work, so a
-post to `/courses/2/…` is course 2 and a post to `/courses/7/…` is
-course 7. After both finish, the session holds the last request’s id.
+Each nested URL still switches to **its** `{id}` in that request’s
+process, so a post to `/courses/2/…` is course 2 and a post to
+`/courses/7/…` is course 7. Concurrent writes do not mix those
+in-request globals. After both finish, leftover `context_id` is
+whichever session write landed last.
 
 That leftover only matters if the next click is **unprefixed**. Nested
 menus stay honest.
@@ -50,6 +54,8 @@ $CFG->setExtension('courses_in_urls', array('you@example.com'));
 ```
 
 Then: `rtrim($CFG->apphome, '/') . Courses::toolPathPrefix() . '/announcements'`.
+The prefix is Google-login only; LMS launches stay unprefixed even when
+the flag is on.
 
 Unset or false keeps menus unprefixed so the feature can ship
 unadvertised. Typed `/courses/{id}/…` URLs still work.

--- a/docs/courses-urls.md
+++ b/docs/courses-urls.md
@@ -1,0 +1,55 @@
+# Course URLs and the current context
+
+Nested paths `/courses/{id}/announcements` (and other tools) name the
+course for **that request**. Bare `/announcements` uses whatever course
+is already in the session.
+
+## Who can use `/courses`
+
+Google site login only (`google.com` key). An LMS LTI launch is refused:
+that session already has a course from the LMS, and course switching is
+not available. Bare tool URLs still work after an LMS launch.
+
+## Course switch
+
+On `/courses/{id}/…`, Tsugi writes `$_SESSION['context_id']` to that id,
+resets the per-request identity snapshot, and drops session caches.
+Then `currentContextId()` is that course for the rest of the request.
+
+Grades and other context caches are tagged with the context id. A
+mismatch is a miss, not a mix-up.
+
+`GET /courses` (no id) does **not** switch. It lists memberships and
+leaves the last nested request’s context in the session.
+
+`GET /courses/{id}` switches, then redirects to the site home.
+
+## Multiple tabs
+
+One PHP session, one `context_id`. PHP serializes requests on that
+session, so two submits do not run in true parallel.
+
+Each nested URL still switches to **its** `{id}` before doing work, so a
+post to `/courses/2/…` is course 2 and a post to `/courses/7/…` is
+course 7. After both finish, the session holds the last request’s id.
+
+That leftover only matters if the next click is **unprefixed**. Nested
+menus stay honest.
+
+## Menus vs controllers
+
+Controllers follow the request path (`toolHome()`). They do not read a
+config flag to decide `/courses/{id}/…` vs `/announcements`.
+
+Parent-site menus may opt in with a temporary extension:
+
+```php
+$CFG->setExtension('courses_in_urls', true);
+// or only some people:
+$CFG->setExtension('courses_in_urls', array('you@example.com'));
+```
+
+Then: `rtrim($CFG->apphome, '/') . Courses::toolPathPrefix() . '/announcements'`.
+
+Unset or false keeps menus unprefixed so the feature can ship
+unadvertised. Typed `/courses/{id}/…` URLs still work.

--- a/lib/include/lms_lib.php
+++ b/lib/include/lms_lib.php
@@ -115,12 +115,18 @@ if (!function_exists('_tsugiIdentitySnapshot')) {
      * - Else if UID exists, choose global pair (UID, CID)
      * - Else none
      *
+     * @param bool $reset When true, drop the cached snapshot so the next call re-reads session/globals.
      * @return array<string,mixed>
      */
-    function _tsugiIdentitySnapshot() {
+    function _tsugiIdentitySnapshot($reset = false) {
         global $USER, $CONTEXT, $DETAIL_LOG;
         static $snapshot = null;
         static $logged = false;
+        if ($reset) {
+            $snapshot = null;
+            $logged = false;
+            return array();
+        }
         if (is_array($snapshot)) {
             return $snapshot;
         }
@@ -225,6 +231,15 @@ if (!function_exists('isLoggedIn')) {
      */
     function isLoggedIn() {
         return loggedInUserId() !== 0;
+    }
+}
+
+if (!function_exists('_tsugiResetIdentitySnapshot')) {
+    /**
+     * Drop the per-request identity snapshot after a mid-request context (or user) change.
+     */
+    function _tsugiResetIdentitySnapshot() {
+        _tsugiIdentitySnapshot(true);
     }
 }
 

--- a/lib/src/Controllers/Courses.php
+++ b/lib/src/Controllers/Courses.php
@@ -4,22 +4,346 @@ namespace Tsugi\Controllers;
 
 use Tsugi\Lumen\Application;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 use \Tsugi\Core\LTIX;
+use \Tsugi\Core\Cache;
+use \Tsugi\Core\Context;
+use \Tsugi\Crypt\SecureCookie;
+use \Tsugi\UI\Output;
+use \Tsugi\Util\U;
 
-class Courses {
+class Courses extends Tool {
 
     const ROUTE = '/courses';
+
+    /** Consumer key used by Google site login. */
+    const GOOGLE_KEY = 'google.com';
+
+    /** @var bool Guard against re-dispatch loops. */
+    private static $dispatchingNested = false;
 
     public static function routes(Application $app, $prefix=self::ROUTE) {
         $app->router->get($prefix.'/json', function(Request $request) use ($app) {
             return Courses::getjson($app);
         });
+        $app->router->get($prefix, function(Request $request) use ($app) {
+            return Courses::index($app, $request);
+        });
+        $app->router->get($prefix.'/', function(Request $request) use ($app) {
+            return Courses::index($app, $request);
+        });
+        $app->router->get($prefix.'/{id:\d+}', function(Request $request, $id) use ($app) {
+            return Courses::enter($app, $request, $id);
+        });
+        $app->router->get($prefix.'/{id:\d+}/', function(Request $request, $id) use ($app) {
+            return Courses::enter($app, $request, $id);
+        });
+        $nested = function(Request $request, $id, $rest) use ($app) {
+            return Courses::nested($app, $request, $id, $rest);
+        };
+        $app->router->get($prefix.'/{id:\d+}/{rest:.*}', $nested);
+        $app->router->post($prefix.'/{id:\d+}/{rest:.*}', $nested);
+    }
+
+    /**
+     * Menu-only path prefix: '' or '/courses/{id}' (no trailing slash).
+     *
+     * Controllers do not call this. Parent menus:
+     * rtrim($CFG->apphome, '/') . Courses::toolPathPrefix() . '/announcements'
+     *
+     * Temporary site flag: $CFG->setExtension('courses_in_urls', true)
+     * or an email allowlist array. Unset/false keeps menus unprefixed.
+     */
+    public static function toolPathPrefix() {
+        global $CFG;
+        $flag = $CFG->getExtension('courses_in_urls', false);
+        if ( empty($flag) ) {
+            return '';
+        }
+        if ( is_array($flag) ) {
+            $email = isset($_SESSION['email']) ? (string) $_SESSION['email'] : '';
+            $allowed = false;
+            foreach ($flag as $candidate) {
+                if ( strcasecmp(trim((string) $candidate), trim($email)) === 0 ) {
+                    $allowed = true;
+                    break;
+                }
+            }
+            if ( ! $allowed ) {
+                return '';
+            }
+        }
+        $cid = U::currentContextId();
+        if ( $cid < 1 ) {
+            return '';
+        }
+        return self::ROUTE . '/' . $cid;
+    }
+
+    /**
+     * True when this session is a Google site login (not an LMS LTI launch).
+     */
+    public static function isGoogleLoginSession() {
+        $postKey = defined('TSUGI_SESSION_LTI_POST') ? TSUGI_SESSION_LTI_POST : 'lti_post';
+        $ltiKey = defined('TSUGI_SESSION_LTI') ? TSUGI_SESSION_LTI : 'lti';
+        if ( ! empty($_SESSION[$postKey]) ) {
+            return false;
+        }
+        $key = isset($_SESSION['oauth_consumer_key']) ? $_SESSION['oauth_consumer_key'] : null;
+        if ( $key === null && isset($_SESSION[$ltiKey]) && is_array($_SESSION[$ltiKey]) ) {
+            $key = isset($_SESSION[$ltiKey]['key_key']) ? $_SESSION[$ltiKey]['key_key'] : null;
+        }
+        return $key === self::GOOGLE_KEY;
+    }
+
+    /**
+     * Switch the Google-login session to $context_id when needed.
+     *
+     * @return true|string true on success, error message otherwise
+     */
+    public static function ensureActiveContext($context_id) {
+        global $CFG, $PDOX, $CONTEXT, $LAUNCH, $TSUGI_LAUNCH;
+
+        $cid = (int) $context_id;
+        if ( $cid < 1 ) {
+            return 'Invalid course.';
+        }
+
+        $current = U::currentContextId();
+        if ( $current === $cid ) {
+            self::wireLaunchConnection();
+            return true;
+        }
+
+        $user_id = U::loggedInUserId();
+        if ( $user_id < 1 ) {
+            return 'Must be logged in.';
+        }
+
+        if ( $PDOX === null || $PDOX === false ) {
+            $PDOX = LTIX::getConnection();
+        }
+        $p = $CFG->dbprefix;
+
+        $context_row = $PDOX->rowDie(
+            "SELECT context_id, context_key, title FROM {$p}lti_context WHERE context_id = :CID",
+            array(':CID' => $cid)
+        );
+        if ( ! $context_row ) {
+            return 'Course not found.';
+        }
+
+        $is_admin = isset($_SESSION['admin']) && $_SESSION['admin'] == 'yes';
+        $member = $PDOX->rowDie(
+            "SELECT membership_id, role, role_override FROM {$p}lti_membership
+             WHERE context_id = :CID AND user_id = :UID",
+            array(':CID' => $cid, ':UID' => $user_id)
+        );
+        if ( ! $is_admin && ! $member ) {
+            return 'You are not a member of that course.';
+        }
+
+        $role = 0;
+        $membership_id = null;
+        if ( $member ) {
+            $r = isset($member['role']) ? ($member['role'] + 0) : 0;
+            $ro = isset($member['role_override']) ? ($member['role_override'] + 0) : 0;
+            $role = max($r, $ro);
+            if ( isset($member['membership_id']) ) {
+                $membership_id = $member['membership_id'] + 0;
+            }
+        }
+        if ( $is_admin && $role < LTIX::ROLE_INSTRUCTOR ) {
+            $role = LTIX::ROLE_INSTRUCTOR;
+        }
+
+        $title = isset($context_row['title']) ? $context_row['title'] : '';
+        $context_key = isset($context_row['context_key']) ? $context_row['context_key'] : '';
+
+        $_SESSION['context_id'] = $cid;
+        $_SESSION['context_key'] = $context_key;
+        $_SESSION['context_title'] = $title;
+        $_SESSION['isinstructor'] = ($role >= LTIX::ROLE_INSTRUCTOR);
+        if ( $membership_id !== null ) {
+            $_SESSION['membership_id'] = $membership_id;
+        } else {
+            unset($_SESSION['membership_id']);
+        }
+
+        $ltiKey = defined('TSUGI_SESSION_LTI') ? TSUGI_SESSION_LTI : 'lti';
+        $lti = isset($_SESSION[$ltiKey]) && is_array($_SESSION[$ltiKey]) ? $_SESSION[$ltiKey] : array();
+        $lti['context_id'] = $cid;
+        $lti['context_key'] = $context_key;
+        $lti['context_title'] = $title;
+        $lti['resource_title'] = $title;
+        $lti['role'] = $role;
+        if ( $membership_id !== null ) {
+            $lti['membership_id'] = $membership_id;
+        } else {
+            unset($lti['membership_id']);
+        }
+        unset($lti['context_settings']);
+        $_SESSION[$ltiKey] = $lti;
+
+        Cache::clearAllSessionCaches();
+        Output::clearTopNavSession();
+
+        if ( function_exists('_tsugiResetIdentitySnapshot') ) {
+            _tsugiResetIdentitySnapshot();
+        }
+
+        // Do not attach Context to the dummy $LAUNCH from lms_lib.php (no pdox).
+        // Null launch objects so buildLaunch() recreates them on $TSUGI_LAUNCH.
+        global $USER, $LINK, $RESULT, $TSUGI_KEY, $PROFILE;
+        $CONTEXT = null;
+        $USER = null;
+        $LINK = null;
+        $RESULT = null;
+        $TSUGI_KEY = null;
+        $PROFILE = null;
+        LTIX::buildLaunch($lti);
+        self::wireLaunchConnection();
+
+        if ( ! empty($CFG->enable_secure_cookie_login) && isset($_SESSION['email']) ) {
+            SecureCookie::set($user_id, $_SESSION['email'], $cid);
+        }
+
+        return true;
+    }
+
+    /**
+     * Point Context/Output at $TSUGI_LAUNCH and ensure it has a PDOX connection.
+     * lms_lib.php may have created a dummy $LAUNCH without pdox.
+     */
+    public static function wireLaunchConnection() {
+        global $PDOX, $TSUGI_LAUNCH, $LAUNCH, $OUTPUT, $CONTEXT;
+
+        if ( ! isset($TSUGI_LAUNCH) || ! is_object($TSUGI_LAUNCH) ) {
+            return;
+        }
+        if ( $PDOX === null || $PDOX === false ) {
+            $PDOX = LTIX::getConnection();
+        }
+        $TSUGI_LAUNCH->pdox = $PDOX;
+        $LAUNCH = $TSUGI_LAUNCH;
+        if ( isset($OUTPUT) && is_object($OUTPUT) ) {
+            $OUTPUT->launch = $TSUGI_LAUNCH;
+            $TSUGI_LAUNCH->output = $OUTPUT;
+        }
+        if ( isset($CONTEXT) && is_object($CONTEXT) ) {
+            $CONTEXT->launch = $TSUGI_LAUNCH;
+            $TSUGI_LAUNCH->context = $CONTEXT;
+        }
+    }
+
+    public static function index(Application $app, Request $request) {
+        global $CFG, $OUTPUT, $PDOX;
+
+        $gate = self::gateResponse();
+        if ( $gate ) {
+            return $gate;
+        }
+
+        if ( $PDOX === null || $PDOX === false ) {
+            $PDOX = LTIX::getConnection();
+        }
+        $p = $CFG->dbprefix;
+        $user_id = U::loggedInUserId();
+
+        $rows = $PDOX->allRowsDie(
+            "SELECT C.context_id, C.title, C.context_key
+             FROM {$p}lti_membership AS M
+             JOIN {$p}lti_context AS C ON M.context_id = C.context_id
+             WHERE M.user_id = :UID
+             ORDER BY C.title, C.context_id",
+            array(':UID' => $user_id)
+        );
+        if ( ! is_array($rows) ) {
+            $rows = array();
+        }
+
+        $tool = new self();
+        $home = $tool->toolHome(self::ROUTE);
+
+        $OUTPUT->header();
+        $OUTPUT->bodyStart();
+        $OUTPUT->topNav();
+        $OUTPUT->flashMessages();
+        ?>
+        <main class="container" id="main-content">
+            <h1>Courses</h1>
+            <?php if ( count($rows) < 1 ) { ?>
+                <p>You are not a member of any courses.</p>
+            <?php } else { ?>
+                <ul>
+                    <?php foreach ( $rows as $row ) {
+                        $id = (int) $row['context_id'];
+                        $title = isset($row['title']) && $row['title'] !== '' ? $row['title'] : ('Course '.$id);
+                        $href = htmlspecialchars($home . '/' . $id);
+                    ?>
+                    <li><a href="<?= $href ?>"><?= htmlspecialchars($title) ?></a></li>
+                    <?php } ?>
+                </ul>
+            <?php } ?>
+        </main>
+        <?php
+        $OUTPUT->footer();
+        return '';
+    }
+
+    public static function enter(Application $app, Request $request, $id) {
+        $gate = self::gateResponse();
+        if ( $gate ) {
+            return $gate;
+        }
+
+        $result = self::ensureActiveContext($id);
+        if ( $result !== true ) {
+            return self::switchFailedResponse($result);
+        }
+
+        return new RedirectResponse(self::configuredHomeUrl());
+    }
+
+    public static function nested(Application $app, Request $request, $id, $rest) {
+        $gate = self::gateResponse();
+        if ( $gate ) {
+            return $gate;
+        }
+
+        $rest = is_string($rest) ? trim($rest, '/') : '';
+        if ( $rest === '' || $rest === 'courses' || str_starts_with($rest, 'courses/') ) {
+            return self::enter($app, $request, $id);
+        }
+
+        $result = self::ensureActiveContext($id);
+        if ( $result !== true ) {
+            return self::switchFailedResponse($result);
+        }
+
+        if ( self::$dispatchingNested ) {
+            return new Response('Nested course dispatch loop', 500);
+        }
+
+        self::$dispatchingNested = true;
+        try {
+            return $app->dispatch(self::innerRequest($request, $rest));
+        } finally {
+            self::$dispatchingNested = false;
+        }
     }
 
     public static function getjson(Application $app)
     {
         global $CFG;
+
+        $gate = self::gateResponse();
+        if ( $gate ) {
+            return $gate;
+        }
+
         $tsugi = $app['tsugi'];
         if ( !isset($tsugi->user)) {
             return \response()->json(
@@ -29,24 +353,70 @@ class Courses {
 
         $PDOX = LTIX::getConnection();
         $p = $CFG->dbprefix;
-        
+
         $row = $PDOX->rowDie("SELECT profile_id FROM {$p}lti_user WHERE user_id = :UID;",
             array(':UID' => $tsugi->user->id)
         );
 
         if ( $row === false || ! isset($row['profile_id']) ) {
-            echo(json_encode(array("error" => "No profile_id")));
-            return;
+            return \response()->json(array("error" => "No profile_id"));
         }
 
         $sql = "SELECT P.profile_id, U.user_id, U.email, C.context_id, C.title
-            FROM profile AS P 
-            JOIN lti_user AS U ON P.profile_id = U.profile_id
-            JOIN lti_membership AS M ON U.user_id = M.user_id
-            JOIN lti_context AS C ON M.context_id = C.context_id
+            FROM {$p}profile AS P
+            JOIN {$p}lti_user AS U ON P.profile_id = U.profile_id
+            JOIN {$p}lti_membership AS M ON U.user_id = M.user_id
+            JOIN {$p}lti_context AS C ON M.context_id = C.context_id
             WHERE P.profile_id = :PID";
 
         $rows = $PDOX->allRowsDie($sql, array(':PID' => $row['profile_id']));
         return response()->json($rows);
+    }
+
+    /**
+     * Build an inner request whose pathInfo is /{rest}.
+     * PHP $_SERVER is unchanged, so toolHome() still sees the nested URL.
+     */
+    public static function innerRequest(Request $request, $rest) {
+        $newPath = '/' . ltrim($rest, '/');
+        $qs = $request->getQueryString();
+        $uri = $newPath . ($qs ? '?'.$qs : '');
+        $params = $request->isMethod('GET') || $request->isMethod('HEAD')
+            ? $request->query->all()
+            : $request->request->all();
+        return Request::create(
+            $uri,
+            $request->getMethod(),
+            $params,
+            $request->cookies->all(),
+            $request->files->all(),
+            $request->server->all(),
+            $request->getContent()
+        );
+    }
+
+    /**
+     * @return Response|null
+     */
+    public static function gateResponse() {
+        if ( ! U::isLoggedIn() ) {
+            return new Response('Must be logged in', 403);
+        }
+        if ( ! self::isGoogleLoginSession() ) {
+            return new Response(
+                'This session is an LTI launch from an LMS. Course switching is not available.',
+                403
+            );
+        }
+        return null;
+    }
+
+    /**
+     * @param string $message
+     * @return Response
+     */
+    private static function switchFailedResponse($message) {
+        $status = ($message === 'You are not a member of that course.') ? 403 : 400;
+        return new Response($message, $status);
     }
 }

--- a/lib/src/Controllers/Courses.php
+++ b/lib/src/Controllers/Courses.php
@@ -55,6 +55,7 @@ class Courses extends Tool {
      *
      * Temporary site flag: $CFG->setExtension('courses_in_urls', true)
      * or an email allowlist array. Unset/false keeps menus unprefixed.
+     * Prefix is Google-login only; LMS launches stay unprefixed.
      */
     public static function toolPathPrefix() {
         global $CFG;
@@ -74,6 +75,9 @@ class Courses extends Tool {
             if ( ! $allowed ) {
                 return '';
             }
+        }
+        if ( ! self::isGoogleLoginSession() ) {
+            return '';
         }
         $cid = U::currentContextId();
         if ( $cid < 1 ) {

--- a/lib/src/Controllers/Discussions.php
+++ b/lib/src/Controllers/Discussions.php
@@ -52,7 +52,7 @@ class Discussions extends Tool {
         $OUTPUT->topNav();
         $OUTPUT->flashMessages();
         echo('<main class="container" id="main-content">');
-        $l->renderDiscussions(false);
+        $l->renderDiscussions(false, $this->toolHome(self::ROUTE));
         echo('</main>');
         $OUTPUT->footer();
 
@@ -64,8 +64,8 @@ class Discussions extends Tool {
         global $CFG;
         $tsugi = $app['tsugi'];
 
-        $path = U::rest_path();
-        $redirect_path = U::addSession($path->parent);
+        $toolHome = self::determineToolHome(self::ROUTE);
+        $redirect_path = U::addSession(self::determineParentPath(self::ROUTE));
         if ( $redirect_path == '') $redirect_path = '/';
 
         if ( ! isset($CFG->lessons) ) {
@@ -130,8 +130,7 @@ class Discussions extends Tool {
             }
         }
 
-        $return_url = $path->parent . '/' . str_replace('_launch', '', $path->controller) ;
-        $parms['launch_presentation_return_url'] = $return_url;
+        $parms['launch_presentation_return_url'] = $toolHome;
 
         $sess_key = 'tsugi_top_nav_'.$CFG->wwwroot;
         if ( isset($_SESSION[$sess_key]) ) {
@@ -236,7 +235,7 @@ class Discussions extends Tool {
     {
         global $CFG, $PDOX;
 
-        $discussions_url = (isset($CFG->apphome) ? $CFG->apphome : $CFG->wwwroot) . self::ROUTE;
+        $discussions_url = $this->toolHome(self::ROUTE);
 
         if ( ! U::isLoggedIn() || ! U::currentContextId() ) {
             U::flashError(__('You must be logged in with a course context to mark discussions as read.'));
@@ -283,7 +282,7 @@ class Discussions extends Tool {
     {
         global $CFG, $PDOX;
 
-        $expire_url = (isset($CFG->apphome) ? $CFG->apphome : $CFG->wwwroot) . self::ROUTE . '/expire-threads';
+        $expire_url = $this->toolHome(self::ROUTE) . '/expire-threads';
         $redirect_url = U::addSession($expire_url);
 
         if ( ! U::isLoggedIn() || ! U::currentContextId() ) {
@@ -418,11 +417,11 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
 
         if ( ! U::isLoggedIn() || ! U::currentContextId() ) {
             U::flashError(__('You must be logged in with a course context to manage discussion expiration.'));
-            return new RedirectResponse(U::addSession(self::ROUTE));
+            return new RedirectResponse(U::addSession($this->toolHome(self::ROUTE)));
         }
         if ( ! $this->isInstructor() ) {
             U::flashError(__('Only instructors can run discussion expiration.'));
-            return new RedirectResponse(U::addSession(self::ROUTE));
+            return new RedirectResponse(U::addSession($this->toolHome(self::ROUTE)));
         }
 
         LTIX::getConnection();
@@ -445,7 +444,7 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
         $oldest_post_at = U::get($oldest_post_row, 'oldest_post_at', null);
         $oldest_thread_at = U::get($oldest_thread_row, 'oldest_thread_at', null);
 
-        $dry_run_url = U::addSession(self::ROUTE.'/expire-threads-dry-run');
+        $dry_run_url = U::addSession($this->toolHome(self::ROUTE).'/expire-threads-dry-run');
         $expire_result = U::get($_SESSION, 'discussions_expire_dry_run_result', false);
         unset($_SESSION['discussions_expire_dry_run_result']);
 
@@ -454,7 +453,7 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
         $OUTPUT->topNav();
         $OUTPUT->flashMessages();
         echo('<main class="container" id="main-content">');
-        echo('<p><a href="'.htmlspecialchars(U::addSession(self::ROUTE.'/manage')).'" class="btn btn-default btn-sm">'.__('Back to Manage Discussions').'</a></p>');
+        echo('<p><a href="'.htmlspecialchars(U::addSession($this->toolHome(self::ROUTE).'/manage')).'" class="btn btn-default btn-sm">'.__('Back to Manage Discussions').'</a></p>');
         $this->renderExpireDryRunPanel($dry_run_url, $expire_result, $oldest_post_at, $oldest_thread_at);
         $this->emitExpireDeleteFormEnhancements();
         echo('</main>');
@@ -465,7 +464,7 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
     {
         global $CFG, $PDOX;
 
-        $expire_url = (isset($CFG->apphome) ? $CFG->apphome : $CFG->wwwroot) . self::ROUTE . '/expire-comments';
+        $expire_url = $this->toolHome(self::ROUTE) . '/expire-comments';
         $redirect_url = U::addSession($expire_url);
 
         if ( ! U::isLoggedIn() || ! U::currentContextId() ) {
@@ -580,11 +579,11 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
 
         if ( ! U::isLoggedIn() || ! U::currentContextId() ) {
             U::flashError(__('You must be logged in with a course context to manage discussion expiration.'));
-            return new RedirectResponse(U::addSession(self::ROUTE));
+            return new RedirectResponse(U::addSession($this->toolHome(self::ROUTE)));
         }
         if ( ! $this->isInstructor() ) {
             U::flashError(__('Only instructors can run discussion expiration.'));
-            return new RedirectResponse(U::addSession(self::ROUTE));
+            return new RedirectResponse(U::addSession($this->toolHome(self::ROUTE)));
         }
 
         LTIX::getConnection();
@@ -599,7 +598,7 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
         );
         $oldest_comment_at = U::get($oldest_comment_row, 'oldest_comment_at', null);
 
-        $dry_run_url = U::addSession(self::ROUTE.'/expire-comments-dry-run');
+        $dry_run_url = U::addSession($this->toolHome(self::ROUTE).'/expire-comments-dry-run');
         $expire_result = U::get($_SESSION, 'discussions_expire_comments_dry_run_result', false);
         unset($_SESSION['discussions_expire_comments_dry_run_result']);
         $tdiscus_threads_ok = $this->ensureTdiscusThreadsLoaded();
@@ -609,7 +608,7 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
         $OUTPUT->topNav();
         $OUTPUT->flashMessages();
         echo('<main class="container" id="main-content">');
-        echo('<p><a href="'.htmlspecialchars(U::addSession(self::ROUTE.'/manage')).'" class="btn btn-default btn-sm">'.__('Back to Manage Discussions').'</a></p>');
+        echo('<p><a href="'.htmlspecialchars(U::addSession($this->toolHome(self::ROUTE).'/manage')).'" class="btn btn-default btn-sm">'.__('Back to Manage Discussions').'</a></p>');
         $this->renderExpireCommentsDryRunPanel($dry_run_url, $expire_result, $oldest_comment_at, $tdiscus_threads_ok);
         $this->emitExpireDeleteFormEnhancements();
         echo('</main>');
@@ -622,11 +621,11 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
 
         if ( ! U::isLoggedIn() || ! U::currentContextId() ) {
             U::flashError(__('You must be logged in with a course context to manage discussions.'));
-            return new RedirectResponse(U::addSession(self::ROUTE));
+            return new RedirectResponse(U::addSession($this->toolHome(self::ROUTE)));
         }
         if ( ! $this->isInstructor() ) {
             U::flashError(__('Only instructors can manage discussions.'));
-            return new RedirectResponse(U::addSession(self::ROUTE));
+            return new RedirectResponse(U::addSession($this->toolHome(self::ROUTE)));
         }
 
         $OUTPUT->header();
@@ -634,7 +633,7 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
         $OUTPUT->topNav();
         $OUTPUT->flashMessages();
         echo('<main class="container" id="main-content">');
-        echo('<p><a href="'.htmlspecialchars(U::addSession(self::ROUTE)).'" class="btn btn-default btn-sm">'.__('Back to Discussions').'</a></p>');
+        echo('<p><a href="'.htmlspecialchars(U::addSession($this->toolHome(self::ROUTE))).'" class="btn btn-default btn-sm">'.__('Back to Discussions').'</a></p>');
         echo('<h1>'.__('Manage Discussions').'</h1>');
         echo('<p>'.__('Discussion maintenance tools for this course context.').'</p>');
         echo('<ul>');
@@ -643,13 +642,13 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
         echo('<li>');
         echo('<a href="#" class="tsugi-discussions-reset-unread-tracking-link">'.__('Reset unread tracking for all users').'</a>');
         echo(' <span class="text-muted">('.__('clears read tracking for this course; subscription preferences are unchanged').')</span>');
-        echo('<form method="post" action="'.htmlspecialchars(U::addSession(self::ROUTE.'/reset-unread-tracking')).'" class="tsugi-discussions-reset-unread-tracking-form" style="display:none;"></form>');
+        echo('<form method="post" action="'.htmlspecialchars(U::addSession($this->toolHome(self::ROUTE).'/reset-unread-tracking')).'" class="tsugi-discussions-reset-unread-tracking-form" style="display:none;"></form>');
         echo('</li>');
         */
-        echo('<li><a href="'.htmlspecialchars(U::addSession(self::ROUTE.'/expire-comments')).'">'.__('Expire old comments').'</a></li>');
-        echo('<li><a href="'.htmlspecialchars(U::addSession(self::ROUTE.'/expire-threads')).'">'.__('Expire old threads').'</a></li>');
+        echo('<li><a href="'.htmlspecialchars(U::addSession($this->toolHome(self::ROUTE).'/expire-comments')).'">'.__('Expire old comments').'</a></li>');
+        echo('<li><a href="'.htmlspecialchars(U::addSession($this->toolHome(self::ROUTE).'/expire-threads')).'">'.__('Expire old threads').'</a></li>');
         echo('<li>');
-        echo('<a href="'.htmlspecialchars(U::addSession(self::ROUTE.'/scan-fix-unread-tracking')).'">'.__('Scan unread tracking (dry run) and optionally fix').'</a>');
+        echo('<a href="'.htmlspecialchars(U::addSession($this->toolHome(self::ROUTE).'/scan-fix-unread-tracking')).'">'.__('Scan unread tracking (dry run) and optionally fix').'</a>');
         echo(' <span class="text-muted">('.__('pre-scan first, then run fix in a second step').')</span>');
         echo('</li>');
         echo('</ul>');
@@ -683,7 +682,7 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
     {
         global $CFG, $PDOX;
 
-        $manage_url = (isset($CFG->apphome) ? $CFG->apphome : $CFG->wwwroot) . self::ROUTE . '/manage';
+        $manage_url = $this->toolHome(self::ROUTE) . '/manage';
         $redirect_url = U::addSession($manage_url);
 
         if ( ! U::isLoggedIn() || ! U::currentContextId() ) {
@@ -742,15 +741,15 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
 
         if ( ! U::isLoggedIn() || ! U::currentContextId() ) {
             U::flashError(__('You must be logged in with a course context to manage discussions.'));
-            return new RedirectResponse(U::addSession(self::ROUTE));
+            return new RedirectResponse(U::addSession($this->toolHome(self::ROUTE)));
         }
         if ( ! $this->isInstructor() ) {
             U::flashError(__('Only instructors can manage discussions.'));
-            return new RedirectResponse(U::addSession(self::ROUTE));
+            return new RedirectResponse(U::addSession($this->toolHome(self::ROUTE)));
         }
         if ( ! U::isNotEmpty($CFG->tdiscus) || ! $CFG->tdiscus ) {
             U::flashError(__('Discussions are not available on this site.'));
-            return new RedirectResponse(U::addSession(self::ROUTE.'/manage'));
+            return new RedirectResponse(U::addSession($this->toolHome(self::ROUTE).'/manage'));
         }
 
         LTIX::getConnection();
@@ -760,14 +759,14 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
         $likely_causes = $this->unreadTrackingLikelyCauses($counts);
         $last_result = U::get($_SESSION, 'discussions_scan_fix_unread_result', false);
         unset($_SESSION['discussions_scan_fix_unread_result']);
-        $run_url = U::addSession(self::ROUTE.'/scan-fix-unread-tracking-run');
+        $run_url = U::addSession($this->toolHome(self::ROUTE).'/scan-fix-unread-tracking-run');
 
         $OUTPUT->header();
         $OUTPUT->bodyStart();
         $OUTPUT->topNav();
         $OUTPUT->flashMessages();
         echo('<main class="container" id="main-content">');
-        echo('<p><a href="'.htmlspecialchars(U::addSession(self::ROUTE.'/manage')).'" class="btn btn-default btn-sm">'.__('Back to Manage Discussions').'</a></p>');
+        echo('<p><a href="'.htmlspecialchars(U::addSession($this->toolHome(self::ROUTE).'/manage')).'" class="btn btn-default btn-sm">'.__('Back to Manage Discussions').'</a></p>');
         echo('<div class="panel panel-info" style="margin-bottom: 1.5em;">');
         echo('<div class="panel-heading"><strong>'.__('Instructor: Unread tracking pre-scan (two phase)').'</strong></div>');
         echo('<div class="panel-body">');
@@ -865,7 +864,7 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
     {
         global $CFG, $PDOX;
 
-        $scan_url = (isset($CFG->apphome) ? $CFG->apphome : $CFG->wwwroot) . self::ROUTE . '/scan-fix-unread-tracking';
+        $scan_url = $this->toolHome(self::ROUTE) . '/scan-fix-unread-tracking';
         $redirect_url = U::addSession($scan_url);
 
         if ( ! U::isLoggedIn() || ! U::currentContextId() ) {

--- a/lib/src/Controllers/Labs.php
+++ b/lib/src/Controllers/Labs.php
@@ -31,7 +31,7 @@ class Labs extends Tool {
         $OUTPUT->bodyStart();
         $OUTPUT->topNav();
         $OUTPUT->flashMessages();
-        LabsUI::renderCatalog($CFG->lessons, rtrim($CFG->apphome, '/') . $this->toolParent(self::ROUTE) . '/lessons_launch/');
+        LabsUI::renderCatalog($CFG->lessons, $this->toolParent(self::ROUTE) . '/lessons_launch/');
         $OUTPUT->footer();
     }
 }

--- a/lib/src/Controllers/Labs.php
+++ b/lib/src/Controllers/Labs.php
@@ -31,7 +31,7 @@ class Labs extends Tool {
         $OUTPUT->bodyStart();
         $OUTPUT->topNav();
         $OUTPUT->flashMessages();
-        LabsUI::renderCatalog($CFG->lessons);
+        LabsUI::renderCatalog($CFG->lessons, rtrim($CFG->apphome, '/') . $this->toolParent(self::ROUTE) . '/lessons_launch/');
         $OUTPUT->footer();
     }
 }

--- a/lib/src/Controllers/LaunchController.php
+++ b/lib/src/Controllers/LaunchController.php
@@ -44,8 +44,8 @@ class LaunchController extends Tool {
     public static function launchByResourceLinkId(Application $app, $resource_link_id) {
         global $CFG;
 
-        $path = U::rest_path();
-        $redirect_path = U::addSession($path->parent);
+        $toolHome = self::determineToolHome(self::ROUTE);
+        $redirect_path = U::addSession(self::determineParentPath(self::ROUTE));
         if ( $redirect_path === '' ) {
             $redirect_path = '/';
         }
@@ -64,7 +64,7 @@ class LaunchController extends Tool {
 
         $module = $l->getModuleByRlid($resource_link_id);
 
-        $return_url = $path->parent . self::ROUTE . '/' . self::RETURN_SEGMENT;
+        $return_url = $toolHome . '/' . self::RETURN_SEGMENT;
 
         $fallback_title = ( $module && isset($module->title) ) ? $module->title : '';
 

--- a/lib/src/Controllers/Lessons.php
+++ b/lib/src/Controllers/Lessons.php
@@ -50,6 +50,7 @@ class Lessons extends Tool {
         }
 
         $l = new \Tsugi\UI\Lessons($CFG->lessons, $anchor);
+        $l->toolHome = $this->toolHome(self::ROUTE);
 
         // If we have an anchor in the path but it doesn't exist, redirect to /lessons
         // (avoids rendering "all lessons" from /lessons/bob which breaks relative URLs)
@@ -181,8 +182,8 @@ class Lessons extends Tool {
     {
         global $CFG;
 
-        $path = U::rest_path();
-        $redirect_path = U::addSession($path->parent);
+        $toolHome = self::determineToolHome(self::ROUTE);
+        $redirect_path = U::addSession(self::determineParentPath(self::ROUTE));
         if ( $redirect_path == '') $redirect_path = '/';
 
         if ( ! isset($CFG->lessons) ) {
@@ -204,10 +205,9 @@ class Lessons extends Tool {
 
         $module = $l->getModuleByRlid($anchor);
 
-        $lessons_base = $path->parent . '/' . str_replace('_launch', '', $path->controller);
         $return_url = $module
-            ? $lessons_base . '/' . $module->anchor
-            : $lessons_base;
+            ? $toolHome . '/' . $module->anchor
+            : $toolHome;
 
         $fallback_title = ( $module && isset($module->title) ) ? $module->title : '';
 

--- a/lib/src/Controllers/Pages.php
+++ b/lib/src/Controllers/Pages.php
@@ -274,6 +274,10 @@ class Pages extends Tool {
         $this->requireAuth();
 
         $apphome = isset($CFG->apphome) ? rtrim($CFG->apphome, '/') : '';
+        $parent = $this->toolParent(self::ROUTE);
+        $lessons_base = $apphome . $parent . '/lessons';
+        $lessons_launch = $apphome . $parent . '/lessons_launch/';
+        $launch_base = $apphome . $parent . '/launch/';
         $lessons_file = isset($CFG->lessons) ? $CFG->lessons : '';
         $items = array();
 
@@ -307,7 +311,7 @@ class Pages extends Tool {
                 $launches_out[] = array(
                     'type' => $type,
                     'title' => $title,
-                    'url' => $apphome . '/launch/' . rawurlencode($rlid),
+                    'url' => $launch_base . rawurlencode($rlid),
                     'resource_link_id' => $rlid,
                     'result' => U::get($launch, 'result', true),
                 );
@@ -321,7 +325,7 @@ class Pages extends Tool {
             if (!empty($module_title) && !empty($module_anchor)) {
                 $top_level_modules[] = array(
                     'title' => $module_title,
-                    'url' => $apphome . '/lessons/' . $module_anchor,
+                    'url' => $lessons_base . '/' . $module_anchor,
                     'anchor' => $module_anchor
                 );
             }
@@ -339,7 +343,7 @@ class Pages extends Tool {
                 if ($type === 'lti' || $type === 'not-lti' || $type === 'discussion') {
                     $resource_link_id = U::get($item, 'resource_link_id', '');
                     if (!empty($resource_link_id)) {
-                        $url = $apphome . '/lessons_launch/' . rawurlencode($resource_link_id);
+                        $url = $lessons_launch . rawurlencode($resource_link_id);
                     }
                 } elseif ($type === 'slide' || $type === 'reference') {
                     $href = U::get($item, 'href', '');

--- a/lib/src/Controllers/Pages.php
+++ b/lib/src/Controllers/Pages.php
@@ -275,9 +275,9 @@ class Pages extends Tool {
 
         $apphome = isset($CFG->apphome) ? rtrim($CFG->apphome, '/') : '';
         $parent = $this->toolParent(self::ROUTE);
-        $lessons_base = $apphome . $parent . '/lessons';
-        $lessons_launch = $apphome . $parent . '/lessons_launch/';
-        $launch_base = $apphome . $parent . '/launch/';
+        $lessons_base = $parent . '/lessons';
+        $lessons_launch = $parent . '/lessons_launch/';
+        $launch_base = $parent . '/launch/';
         $lessons_file = isset($CFG->lessons) ? $CFG->lessons : '';
         $items = array();
 

--- a/lib/src/Controllers/Tool.php
+++ b/lib/src/Controllers/Tool.php
@@ -160,36 +160,38 @@ abstract class Tool {
     }
 
     /**
-     * Get the base path for this tool (e.g., '/py4e/pages' or '/py4e/12345/pages')
-     * 
-     * This method determines where the tool is actually mounted by examining
-     * the current request URI and finding the tool's route within it.
-     * 
+     * Get the base path for this tool (e.g., '/py4e/pages' or '/courses/2/pages')
+     *
+     * Looks at the current request URI and finds the tool's route within it,
+     * so nested mounts keep generating nested URLs.
+     *
      * @param string $route The route constant for this tool (e.g., '/pages', '/announcements')
      * @return string The base path including the route (e.g., '/py4e/pages')
      */
     protected function toolHome($route) {
-        // Get the current request URI
+        return self::determineToolHome($route);
+    }
+
+    /**
+     * Static form of {@see toolHome()} for launch methods that have no instance.
+     *
+     * @param string $route The route constant (e.g., '/discussions')
+     * @return string The mounted tool path (e.g., '/courses/2/discussions')
+     */
+    public static function determineToolHome($route) {
         $requestUri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '';
-        
-        // Remove query string if present
         $requestUri = strtok($requestUri, '?');
-        
-        // Find where the route appears in the URI
+
         $routePos = strpos($requestUri, $route);
-        
         if ($routePos !== false) {
-            // Return everything up to and including the route
             return substr($requestUri, 0, $routePos + strlen($route));
         }
-        
-        // Fallback: if route not found, try using rest_path
+
         $path = U::rest_path();
         if ($path && isset($path->parent)) {
             return $path->parent . $route;
         }
-        
-        // Last resort: use apphome (for backward compatibility)
+
         global $CFG;
         return isset($CFG->apphome) ? $CFG->apphome . $route : $route;
     }
@@ -301,7 +303,7 @@ abstract class Tool {
             }
         } else {
             // Try to detect by looking for common controller routes
-            $controllerRoutes = ['/announcements', '/pages', '/badges', '/grades', '/lessons', '/launch', '/assignments', '/map', '/login', '/logout'];
+            $controllerRoutes = ['/announcements', '/pages', '/badges', '/grades', '/lessons', '/discussions', '/topics', '/launch', '/assignments', '/map', '/login', '/logout'];
             foreach ($controllerRoutes as $testRoute) {
                 $routePos = strpos($requestUri, $testRoute);
                 if ($routePos !== false) {

--- a/lib/src/Controllers/Topics.php
+++ b/lib/src/Controllers/Topics.php
@@ -9,7 +9,7 @@ use Tsugi\Lumen\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
-class Topics {
+class Topics extends Tool {
 
     const ROUTE = '/topics';
 
@@ -44,6 +44,7 @@ class Topics {
 
         // Load the Topic
         $t = new \Tsugi\UI\Topics($CFG->topics,$anchor);
+        $t->toolHome = $this->toolHome(self::ROUTE);
 
         $OUTPUT->header();
         $OUTPUT->bodyStart();
@@ -64,8 +65,8 @@ class Topics {
         global $CFG;
         $tsugi = $app['tsugi'];
 
-        $path = U::rest_path();
-        $redirect_path = U::addSession($path->parent);
+        $toolHome = self::determineToolHome(self::ROUTE);
+        $redirect_path = U::addSession(self::determineParentPath(self::ROUTE));
         if ( $redirect_path == '') $redirect_path = '/';
 
         if ( ! isset($CFG->topics) ) {
@@ -137,8 +138,7 @@ class Topics {
             }
         }
 
-        $return_url = $path->parent . '/' . str_replace('_launch', '', $path->controller) . '/' . $topic->anchor;
-        $parms['launch_presentation_return_url'] = $return_url;
+        $parms['launch_presentation_return_url'] = $toolHome . '/' . $topic->anchor;
 
         $sess_key = 'tsugi_top_nav_'.$CFG->wwwroot;
         if ( isset($_SESSION[$sess_key]) ) {

--- a/lib/src/UI/Labs.php
+++ b/lib/src/UI/Labs.php
@@ -163,12 +163,14 @@ class Labs {
         echo('</main>'."\n");
     }
 
-    public static function renderCatalog($lessons_path) {
+    public static function renderCatalog($lessons_path, $launch_base=null) {
         global $CFG;
 
         $labs_items = self::collectLtiItems($lessons_path);
         $can_launch = self::canLaunch();
-        $launch_base = $CFG->apphome . '/lessons_launch/';
+        if ( $launch_base === null || $launch_base === '' ) {
+            $launch_base = $CFG->apphome . '/lessons_launch/';
+        }
 
         $allgrades = array();
         $duedates = array();

--- a/lib/src/UI/Lessons.php
+++ b/lib/src/UI/Lessons.php
@@ -38,6 +38,12 @@ class Lessons {
      */
     public $resource_links;
 
+    /**
+     * Mounted lessons path (e.g. /lessons or /courses/2/lessons).
+     * Set by the Lessons controller; otherwise derived from REQUEST_URI.
+     */
+    public $toolHome = '';
+
     /** @var array Grades by resource_link_id for due badges on single-module view */
     private $lessonModuleGradesForBadges = array();
 
@@ -188,6 +194,23 @@ class Lessons {
         ob_end_clean();
         if ( $buffer ) return $ob_output;
         echo($ob_output);
+    }
+
+    /**
+     * Mounted lessons path: /lessons or /courses/{id}/lessons.
+     */
+    private function lessonsHome() {
+        if ( is_string($this->toolHome) && $this->toolHome !== '' ) {
+            return $this->toolHome;
+        }
+        return \Tsugi\Controllers\Tool::determineToolHome('/lessons');
+    }
+
+    /**
+     * LTI launch URL for a lessons resource_link_id (sibling _launch route).
+     */
+    private function lessonsLaunchPath($resource_link_id) {
+        return $this->lessonsHome() . '_launch/' . $resource_link_id;
     }
 
     /*
@@ -1385,8 +1408,7 @@ class Lessons {
                         continue;
                     }
 
-                    $rest_path = U::rest_path();
-                    $launch_path = $rest_path->parent . '/' . $rest_path->controller . '_launch/' . $discussion->resource_link_id;
+                    $launch_path = $this->lessonsLaunchPath($discussion->resource_link_id);
                     $title = isset($discussion->title) ? $discussion->title : "Discussion";
                     echo('<li class="tsugi-lessons-module-discussion"><a href="'.$launch_path.'">'.htmlentities($title).'</a></li>'."\n");
                     echo("\n</li>\n");
@@ -1435,8 +1457,7 @@ class Lessons {
                         continue;
                     }
 
-                    $rest_path = U::rest_path();
-                    $launch_path = $rest_path->parent . '/' . $rest_path->controller . '_launch/' . $lti->resource_link_id;
+                    $launch_path = $this->lessonsLaunchPath($lti->resource_link_id);
                     $title = isset($lti->title) ? $lti->title : "Autograder";
                     $target = isset($lti->target) ? $lti->target : false;
 
@@ -2154,9 +2175,8 @@ class Lessons {
 
                 echo('<tr><td>');
 
-                $rest_path = U::rest_path();
                 $href= "Missing ". $resource_link_id;
-                if ($module != null )  $href = $rest_path->parent . '/lessons/' . urlencode($module->anchor);
+                if ($module != null )  $href = $this->lessonsHome() . '/' . urlencode($module->anchor);
 
                 $badge_title = "Missing ". $resource_link_id;
                 if ( $lti != null ) $badge_title = $lti->title;
@@ -2262,7 +2282,7 @@ class Lessons {
         echo($ob_output);
     }
 
-    public function renderDiscussions($buffer=false)
+    public function renderDiscussions($buffer=false, $toolHome=null)
     {
         ob_start();
         global $CFG, $OUTPUT, $PDOX;
@@ -2308,10 +2328,12 @@ class Lessons {
             return;
         }
 
-        $rest_path = U::rest_path();
-        $json_endpoint = U::addSession($rest_path->parent . '/' . $rest_path->controller . '/json');
-        $mark_read_url = U::addSession($rest_path->parent . '/' . $rest_path->controller . '/mark-read');
-        $manage_discussions_url = U::addSession($rest_path->parent . '/' . $rest_path->controller . '/manage');
+        if ( $toolHome === null || $toolHome === '' ) {
+            $toolHome = \Tsugi\Controllers\Tool::determineToolHome('/discussions');
+        }
+        $json_endpoint = U::addSession($toolHome . '/json');
+        $mark_read_url = U::addSession($toolHome . '/mark-read');
+        $manage_discussions_url = U::addSession($toolHome . '/manage');
 
         echo('<h1>'.__('Discussions:').' '.$this->lessons->title."</h1>\n");
 
@@ -2347,7 +2369,7 @@ class Lessons {
         echo('<ul class="tsugi-lessons-module-discussions-ul"> <!-- start of discussions -->'."\n");
         foreach($discussions as $discussion ) {
             $resource_link_title = $discussion->title;
-            $launch_path = $rest_path->parent . '/' . $rest_path->controller . '_launch/' . $discussion->resource_link_id;
+            $launch_path = $toolHome . '_launch/' . $discussion->resource_link_id;
             $info = "";
             $row = U::get($rows_dict, $discussion->resource_link_id);
             $subscribed_threads = intval(U::get($row, 'subscribed_threads', 0));
@@ -2979,8 +3001,7 @@ $(function(){
                 return;
             }
             
-            $rest_path = U::rest_path();
-            $launch_path = $rest_path->parent . '/' . $rest_path->controller . '_launch/' . $resource_link_id;
+            $launch_path = $this->lessonsLaunchPath($resource_link_id);
             echo('<li class="tsugi-lessons-module-discussion">');
             echo('<a href="'.$launch_path.'" style="display: inline-flex; align-items: center;">');
             self::renderItemIcon('discussion');
@@ -3026,8 +3047,7 @@ $(function(){
                 return;
             }
             
-            $rest_path = U::rest_path();
-            $launch_path = $rest_path->parent . '/' . $rest_path->controller . '_launch/' . $resource_link_id;
+            $launch_path = $this->lessonsLaunchPath($resource_link_id);
             $title = isset($item->title) ? $item->title : "Autograder";
             
             $rl_dom_id = self::domIdForResourceLink($resource_link_id);

--- a/lib/src/UI/Topics.php
+++ b/lib/src/UI/Topics.php
@@ -46,6 +46,11 @@ class Topics {
      */
     public $resource_links;
 
+    /**
+     * Mounted topics path (e.g. /topics or /courses/2/topics).
+     */
+    public $toolHome = '';
+
     public function __construct($name='topics.json', $anchor=null, $index=null)
     {
         global $CFG;
@@ -379,6 +384,17 @@ class Topics {
         return null;
     }
 
+    private function topicsHome() {
+        if ( is_string($this->toolHome) && $this->toolHome !== '' ) {
+            return $this->toolHome;
+        }
+        return \Tsugi\Controllers\Tool::determineToolHome('/topics');
+    }
+
+    private function topicsLaunchPath($resource_link_id) {
+        return $this->topicsHome() . '_launch/' . $resource_link_id;
+    }
+
     public function render($buffer=false) {
         if ( $this->isSingle() ) {
             return $this->renderSingle($buffer);
@@ -490,8 +506,7 @@ class Topics {
                     foreach($ltis as $lti ) {
                         $resource_link_title = isset($lti->title) ? $lti->title : $topic->title;
 
-                        $rest_path = U::rest_path();
-                        $launch_path = $rest_path->parent . '/' . $rest_path->controller . '_launch/' . $lti->resource_link_id;
+                        $launch_path = $this->topicsLaunchPath($lti->resource_link_id);
                         $title = isset($lti->title) ? $lti->title : $topic->title;
                         ?>
                         <div class="videoWrapper">

--- a/lib/tests/Controllers/CoursesControllerTest.php
+++ b/lib/tests/Controllers/CoursesControllerTest.php
@@ -215,6 +215,19 @@ class CoursesControllerTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('/courses/42', Courses::toolPathPrefix());
     }
 
+    public function testToolPathPrefixEmptyForLtiLaunch()
+    {
+        global $CFG;
+        $_SESSION['id'] = 7;
+        $_SESSION['context_id'] = 42;
+        $_SESSION['oauth_consumer_key'] = 'canvas.example.edu';
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+        $CFG->setExtension('courses_in_urls', true);
+        $this->assertSame('', Courses::toolPathPrefix());
+    }
+
     public function testInnerRequestPathInfo()
     {
         $request = Request::create('/courses/42/announcements/manage', 'GET', array('x' => '1'));

--- a/lib/tests/Controllers/CoursesControllerTest.php
+++ b/lib/tests/Controllers/CoursesControllerTest.php
@@ -1,30 +1,35 @@
 <?php
 
 require_once "src/Controllers/Courses.php";
+require_once "src/Controllers/Tool.php";
 require_once "src/Config/ConfigInfo.php";
 require_once "src/Lumen/Application.php";
 require_once "src/Lumen/Router.php";
+require_once "src/Util/U.php";
 
 use \Tsugi\Controllers\Courses;
 use \Tsugi\Lumen\Application;
+use Symfony\Component\HttpFoundation\Request;
 
 class CoursesControllerTest extends \PHPUnit\Framework\TestCase
 {
     private $originalCFG;
+    private $originalSession;
     private $mockLaunch;
     private $mockApp;
-    
+
     protected function setUp(): void
     {
         global $CFG;
         $this->originalCFG = $CFG;
-        
-        // Set up test CFG
+        $this->originalSession = isset($_SESSION) && is_array($_SESSION) ? $_SESSION : array();
+        $_SESSION = array();
+
         $CFG = new \Tsugi\Config\ConfigInfo(basename(__FILE__), 'http://localhost');
         $CFG->wwwroot = 'http://localhost';
         $CFG->apphome = 'http://localhost/app';
-        
-        // Set up loader if not already set
+        $CFG->dirroot = dirname(__DIR__, 3);
+
         if (!isset($CFG->loader)) {
             $autoloaderPath = __DIR__ . '/../../vendor/autoload.php';
             if (file_exists($autoloaderPath)) {
@@ -33,55 +38,203 @@ class CoursesControllerTest extends \PHPUnit\Framework\TestCase
                 $CFG->loader = new \stdClass();
             }
         }
-        
-        // Create a simple launch object
+
+        if (!function_exists('isLoggedIn')) {
+            require_once dirname(__DIR__, 2) . '/include/lms_lib.php';
+        }
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+
         $this->mockLaunch = new \stdClass();
         $this->mockLaunch->output = new \stdClass();
         $this->mockLaunch->output->buffer = true;
-        
-        // Create a mock application
+
         $this->mockApp = new Application($this->mockLaunch);
     }
-    
+
     protected function tearDown(): void
     {
         global $CFG;
         $CFG = $this->originalCFG;
+        $_SESSION = $this->originalSession;
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
     }
-    
-    /**
-     * Test that Courses::routes() registers routes correctly
-     */
-    public function testRoutesRegistersCorrectRoutes()
+
+    private function routeUris(): array
     {
-        // Register routes
         Courses::routes($this->mockApp);
-        
-        // Get registered routes
-        $routes = $this->mockApp->router->getRoutes();
-        
-        // Extract URIs from routes
         $uris = [];
-        foreach ($routes as $route) {
+        foreach ($this->mockApp->router->getRoutes() as $route) {
             $uris[] = $route['uri'];
         }
-        
-        // Should have /courses/json route
-        $hasCoursesJsonRoute = false;
-        foreach ($uris as $uri) {
-            if (strpos($uri, '/courses/json') === 0) {
-                $hasCoursesJsonRoute = true;
-                break;
-            }
-        }
-        $this->assertTrue($hasCoursesJsonRoute, 'Should register /courses/json route');
+        return $uris;
     }
-    
-    /**
-     * Test that ROUTE constant is correct
-     */
+
+    public function testRoutesRegistersCorrectRoutes()
+    {
+        $uris = $this->routeUris();
+
+        $this->assertContains('/courses/json', $uris);
+        $this->assertContains('/courses', $uris);
+        $this->assertContains('/courses/{id:\d+}', $uris);
+        $this->assertContains('/courses/{id:\d+}/{rest:.*}', $uris);
+    }
+
     public function testRouteConstant()
     {
         $this->assertEquals('/courses', Courses::ROUTE, 'ROUTE constant should be /courses');
+    }
+
+    public function testIsGoogleLoginSessionTrue()
+    {
+        $_SESSION['oauth_consumer_key'] = 'google.com';
+        $this->assertTrue(Courses::isGoogleLoginSession());
+    }
+
+    public function testIsGoogleLoginSessionFalseWhenLtiPost()
+    {
+        $_SESSION['oauth_consumer_key'] = 'google.com';
+        $_SESSION['lti_post'] = array('context_id' => 'lms-course');
+        $this->assertFalse(Courses::isGoogleLoginSession());
+    }
+
+    public function testIsGoogleLoginSessionFalseWhenOtherKey()
+    {
+        $_SESSION['oauth_consumer_key'] = 'canvas.example.edu';
+        $this->assertFalse(Courses::isGoogleLoginSession());
+    }
+
+    public function testIsGoogleLoginSessionFromLtiBlob()
+    {
+        $_SESSION['lti'] = array('key_key' => 'google.com');
+        $this->assertTrue(Courses::isGoogleLoginSession());
+    }
+
+    public function testGateRequiresLogin()
+    {
+        $response = Courses::gateResponse();
+        $this->assertNotNull($response);
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertStringContainsString('logged in', $response->getContent());
+    }
+
+    public function testGateRefusesLtiLaunch()
+    {
+        $_SESSION['id'] = 7;
+        $_SESSION['oauth_consumer_key'] = 'canvas.example.edu';
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+        $response = Courses::gateResponse();
+        $this->assertNotNull($response);
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertStringContainsString('LTI launch', $response->getContent());
+    }
+
+    public function testGateAllowsGoogleLogin()
+    {
+        $_SESSION['id'] = 7;
+        $_SESSION['oauth_consumer_key'] = 'google.com';
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+        $this->assertNull(Courses::gateResponse());
+    }
+
+    public function testEnsureActiveContextNoOpWhenSame()
+    {
+        $_SESSION['id'] = 7;
+        $_SESSION['context_id'] = 42;
+        $_SESSION['oauth_consumer_key'] = 'google.com';
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+        $this->assertTrue(Courses::ensureActiveContext(42));
+    }
+
+    public function testWireLaunchConnectionSetsPdoxOnTsugiLaunch()
+    {
+        global $TSUGI_LAUNCH, $LAUNCH, $OUTPUT, $CONTEXT, $PDOX;
+        $save = array($TSUGI_LAUNCH ?? null, $LAUNCH ?? null, $OUTPUT ?? null, $CONTEXT ?? null, $PDOX ?? null);
+        $TSUGI_LAUNCH = new \Tsugi\Core\Launch();
+        $LAUNCH = new \Tsugi\Core\Launch();
+        $CONTEXT = new \Tsugi\Core\Context();
+        $OUTPUT = new \Tsugi\UI\Output();
+        $PDOX = new \stdClass();
+        Courses::wireLaunchConnection();
+        $this->assertSame($PDOX, $TSUGI_LAUNCH->pdox);
+        $this->assertSame($TSUGI_LAUNCH, $LAUNCH);
+        $this->assertSame($TSUGI_LAUNCH, $CONTEXT->launch);
+        $this->assertSame($TSUGI_LAUNCH, $OUTPUT->launch);
+        [$TSUGI_LAUNCH, $LAUNCH, $OUTPUT, $CONTEXT, $PDOX] = $save;
+    }
+
+    public function testToolPathPrefixOffByDefault()
+    {
+        global $CFG;
+        $_SESSION['id'] = 7;
+        $_SESSION['context_id'] = 42;
+        $_SESSION['oauth_consumer_key'] = 'google.com';
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+        $this->assertSame('', Courses::toolPathPrefix());
+    }
+
+    public function testToolPathPrefixWhenEnabled()
+    {
+        global $CFG;
+        $_SESSION['id'] = 7;
+        $_SESSION['context_id'] = 42;
+        $_SESSION['email'] = 'you@example.com';
+        $_SESSION['oauth_consumer_key'] = 'google.com';
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+        $CFG->setExtension('courses_in_urls', true);
+        $this->assertSame('/courses/42', Courses::toolPathPrefix());
+    }
+
+    public function testToolPathPrefixEmailAllowlist()
+    {
+        global $CFG;
+        $_SESSION['id'] = 7;
+        $_SESSION['context_id'] = 42;
+        $_SESSION['email'] = 'you@example.com';
+        $_SESSION['oauth_consumer_key'] = 'google.com';
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+        $CFG->setExtension('courses_in_urls', array('other@example.com'));
+        $this->assertSame('', Courses::toolPathPrefix());
+
+        $CFG->setExtension('courses_in_urls', array('you@example.com'));
+        $this->assertSame('/courses/42', Courses::toolPathPrefix());
+    }
+
+    public function testInnerRequestPathInfo()
+    {
+        $request = Request::create('/courses/42/announcements/manage', 'GET', array('x' => '1'));
+        $inner = Courses::innerRequest($request, 'announcements/manage');
+        $this->assertSame('/announcements/manage', $inner->getPathInfo());
+        $this->assertSame('GET', $inner->getMethod());
+        $this->assertSame('1', $inner->query->get('x'));
+    }
+
+    public function testIdentitySnapshotResetAfterContextChange()
+    {
+        $_SESSION['id'] = 7;
+        $_SESSION['context_id'] = 1;
+        _tsugiResetIdentitySnapshot();
+        $this->assertSame(1, currentContextId());
+
+        $_SESSION['context_id'] = 99;
+        $this->assertSame(1, currentContextId(), 'snapshot must stick until reset');
+
+        _tsugiResetIdentitySnapshot();
+        $this->assertSame(99, currentContextId());
     }
 }

--- a/lib/tests/Controllers/DiscussionsControllerTest.php
+++ b/lib/tests/Controllers/DiscussionsControllerTest.php
@@ -121,4 +121,34 @@ class DiscussionsControllerTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals('/discussions', Discussions::ROUTE, 'ROUTE constant should be /discussions');
     }
+
+    /**
+     * Nested /courses/{id}/discussions must keep generating nested launch URLs.
+     */
+    public function testDetermineToolHomeFollowsRequestUri()
+    {
+        $originalUri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : null;
+
+        $_SERVER['REQUEST_URI'] = '/courses/2/discussions';
+        $home = \Tsugi\Controllers\Tool::determineToolHome(Discussions::ROUTE);
+        $this->assertEquals('/courses/2/discussions', $home);
+        $this->assertEquals('/courses/2/discussions_launch/discussion_features',
+            $home . '_launch/discussion_features');
+
+        $_SERVER['REQUEST_URI'] = '/discussions';
+        $home = \Tsugi\Controllers\Tool::determineToolHome(Discussions::ROUTE);
+        $this->assertEquals('/discussions', $home);
+        $this->assertEquals('/discussions_launch/discussion_features',
+            $home . '_launch/discussion_features');
+
+        $_SERVER['REQUEST_URI'] = '/courses/2/discussions_launch/discussion_features';
+        $home = \Tsugi\Controllers\Tool::determineToolHome(Discussions::ROUTE);
+        $this->assertEquals('/courses/2/discussions', $home);
+
+        if ( $originalUri === null ) {
+            unset($_SERVER['REQUEST_URI']);
+        } else {
+            $_SERVER['REQUEST_URI'] = $originalUri;
+        }
+    }
 }

--- a/lib/tests/Controllers/DiscussionsControllerTest.php
+++ b/lib/tests/Controllers/DiscussionsControllerTest.php
@@ -128,27 +128,28 @@ class DiscussionsControllerTest extends \PHPUnit\Framework\TestCase
     public function testDetermineToolHomeFollowsRequestUri()
     {
         $originalUri = isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : null;
+        try {
+            $_SERVER['REQUEST_URI'] = '/courses/2/discussions';
+            $home = \Tsugi\Controllers\Tool::determineToolHome(Discussions::ROUTE);
+            $this->assertEquals('/courses/2/discussions', $home);
+            $this->assertEquals('/courses/2/discussions_launch/discussion_features',
+                $home . '_launch/discussion_features');
 
-        $_SERVER['REQUEST_URI'] = '/courses/2/discussions';
-        $home = \Tsugi\Controllers\Tool::determineToolHome(Discussions::ROUTE);
-        $this->assertEquals('/courses/2/discussions', $home);
-        $this->assertEquals('/courses/2/discussions_launch/discussion_features',
-            $home . '_launch/discussion_features');
+            $_SERVER['REQUEST_URI'] = '/discussions';
+            $home = \Tsugi\Controllers\Tool::determineToolHome(Discussions::ROUTE);
+            $this->assertEquals('/discussions', $home);
+            $this->assertEquals('/discussions_launch/discussion_features',
+                $home . '_launch/discussion_features');
 
-        $_SERVER['REQUEST_URI'] = '/discussions';
-        $home = \Tsugi\Controllers\Tool::determineToolHome(Discussions::ROUTE);
-        $this->assertEquals('/discussions', $home);
-        $this->assertEquals('/discussions_launch/discussion_features',
-            $home . '_launch/discussion_features');
-
-        $_SERVER['REQUEST_URI'] = '/courses/2/discussions_launch/discussion_features';
-        $home = \Tsugi\Controllers\Tool::determineToolHome(Discussions::ROUTE);
-        $this->assertEquals('/courses/2/discussions', $home);
-
-        if ( $originalUri === null ) {
-            unset($_SERVER['REQUEST_URI']);
-        } else {
-            $_SERVER['REQUEST_URI'] = $originalUri;
+            $_SERVER['REQUEST_URI'] = '/courses/2/discussions_launch/discussion_features';
+            $home = \Tsugi\Controllers\Tool::determineToolHome(Discussions::ROUTE);
+            $this->assertEquals('/courses/2/discussions', $home);
+        } finally {
+            if ( $originalUri === null ) {
+                unset($_SERVER['REQUEST_URI']);
+            } else {
+                $_SERVER['REQUEST_URI'] = $originalUri;
+            }
         }
     }
 }

--- a/phpstan-stubs.php
+++ b/phpstan-stubs.php
@@ -93,6 +93,13 @@ namespace {
     {
         return 0;
     }
+
+    /**
+     * @return void
+     */
+    function _tsugiResetIdentitySnapshot(): void
+    {
+    }
 }
 
 namespace Ratchet {


### PR DESCRIPTION
Google-login sessions can switch course from the path; menus stay unprefixed unless a site opts in with the courses_in_urls extension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added course-aware URLs, including `/courses/{id}/...`.
  * Added course selection and switching, with the active course reflected across the session.
  * Added optional course-prefixed menu URLs for Google-login users; LMS launches remain unprefixed.

* **Bug Fixes**
  * Corrected links, redirects, launch URLs, and lesson or discussion paths under courses.
  * Prevented direct web access to configuration files.

* **Documentation**
  * Documented course URL behavior, session context, access rules, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->