### PR TITLE
Add Course Authoring in the Database with the mainifest table

### DIFF
--- a/admin/lti/database.php
+++ b/admin/lti/database.php
@@ -258,6 +258,7 @@ array( "{$CFG->dbprefix}manifest",
     context_id          INTEGER NOT NULL,
     version             INTEGER NOT NULL,
     title               TEXT NULL,
+    theme               VARCHAR(64) NULL,
     manifest            MEDIUMTEXT NOT NULL,
     comment             TEXT NULL,
     user_id             INTEGER NULL,
@@ -777,6 +778,9 @@ $DATABASE_UPGRADE = function($oldversion) {
 
         // 2026-08-28 Active course manifest version (NULL = file-based $CFG->lessons)
         array('lti_context', 'manifest_id', 'INTEGER NULL'),
+
+        // 2026-08-28 Named course theme key (NULL = site $CFG->theme)
+        array('manifest', 'theme', 'VARCHAR(64) NULL'),
     );
 
     foreach ( $add_some_fields as $add_field ) {

--- a/admin/lti/database.php
+++ b/admin/lti/database.php
@@ -158,6 +158,9 @@ array( "{$CFG->dbprefix}lti_user",
     image               TEXT NULL,
     subscribe           SMALLINT NULL,
 
+    -- Site-level capability to mint courses (not an LTI membership role)
+    create_courses      TINYINT(1) NOT NULL DEFAULT 0,
+
     json                MEDIUMTEXT NULL,
     login_at            TIMESTAMP NULL,
     login_count         BIGINT DEFAULT 0,
@@ -783,6 +786,9 @@ $DATABASE_UPGRADE = function($oldversion) {
 
         // 2026-08-28 Named course theme key (NULL = site $CFG->theme)
         array('manifest', 'theme', 'VARCHAR(64) NULL'),
+
+        // 2026-08-28 User-level capability to create site-login courses
+        array('lti_user', 'create_courses', 'TINYINT(1) NOT NULL DEFAULT 0'),
     );
 
     foreach ( $add_some_fields as $add_field ) {
@@ -1436,7 +1442,7 @@ $DATABASE_UPGRADE = function($oldversion) {
 
     // When you increase this number in any database.php file,
     // make sure to update the global value in setup.php
-    return 202610010001;
+    return 202610010003;
 
 }; // Don't forget the semicolon on anonymous functions :)
 

--- a/admin/lti/database.php
+++ b/admin/lti/database.php
@@ -16,6 +16,7 @@ $DATABASE_UNINSTALL = array(
 "drop table if exists {$CFG->dbprefix}lti_link",
 "drop table if exists {$CFG->dbprefix}lti_link_activity",
 "drop table if exists {$CFG->dbprefix}lti_link_user_activity",
+"drop table if exists {$CFG->dbprefix}manifest",
 "drop table if exists {$CFG->dbprefix}lti_context",
 "drop table if exists {$CFG->dbprefix}lti_user",
 "drop table if exists {$CFG->dbprefix}lti_issuer",
@@ -230,6 +231,9 @@ array( "{$CFG->dbprefix}lti_context",
 
     viewDueDates        TINYINT(1) NOT NULL DEFAULT 1,
 
+    -- Active course manifest version (NULL = file-based $CFG->lessons)
+    manifest_id         INTEGER NULL,
+
     created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at          TIMESTAMP NULL,
     deleted_at          TIMESTAMP NULL,
@@ -246,6 +250,33 @@ array( "{$CFG->dbprefix}lti_context",
 
     CONSTRAINT `{$CFG->dbprefix}lti_context_const_1` UNIQUE(key_id, context_sha256),
     CONSTRAINT `{$CFG->dbprefix}lti_context_const_pk` PRIMARY KEY (context_id)
+) ENGINE = InnoDB DEFAULT CHARSET=utf8"),
+
+array( "{$CFG->dbprefix}manifest",
+"create table {$CFG->dbprefix}manifest (
+    manifest_id         INTEGER NOT NULL AUTO_INCREMENT,
+    context_id          INTEGER NOT NULL,
+    version             INTEGER NOT NULL,
+    title               TEXT NULL,
+    manifest            MEDIUMTEXT NOT NULL,
+    comment             TEXT NULL,
+    user_id             INTEGER NULL,
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT `{$CFG->dbprefix}manifest_const_pk` PRIMARY KEY (manifest_id),
+    CONSTRAINT `{$CFG->dbprefix}manifest_const_1` UNIQUE (context_id, version),
+
+    CONSTRAINT `{$CFG->dbprefix}manifest_ibfk_1`
+        FOREIGN KEY (`context_id`)
+        REFERENCES `{$CFG->dbprefix}lti_context` (`context_id`)
+        ON DELETE CASCADE ON UPDATE CASCADE,
+
+    CONSTRAINT `{$CFG->dbprefix}manifest_ibfk_2`
+        FOREIGN KEY (`user_id`)
+        REFERENCES `{$CFG->dbprefix}lti_user` (`user_id`)
+        ON DELETE SET NULL ON UPDATE CASCADE,
+
+    INDEX `{$CFG->dbprefix}manifest_indx_1` (context_id)
 ) ENGINE = InnoDB DEFAULT CHARSET=utf8"),
 
 array( "{$CFG->dbprefix}lti_link",
@@ -743,6 +774,9 @@ $DATABASE_UPGRADE = function($oldversion) {
         // 2026-03-29 Per-context and per-membership visibility for due dates (existing rows default to on)
         array('lti_context', 'viewDueDates', 'TINYINT(1) NOT NULL DEFAULT 1'),
         array('lti_membership', 'viewDueDates', 'TINYINT(1) NOT NULL DEFAULT 1'),
+
+        // 2026-08-28 Active course manifest version (NULL = file-based $CFG->lessons)
+        array('lti_context', 'manifest_id', 'INTEGER NULL'),
     );
 
     foreach ( $add_some_fields as $add_field ) {
@@ -1396,7 +1430,7 @@ $DATABASE_UPGRADE = function($oldversion) {
 
     // When you increase this number in any database.php file,
     // make sure to update the global value in setup.php
-    return 202610010000;
+    return 202610010001;
 
 }; // Don't forget the semicolon on anonymous functions :)
 

--- a/admin/lti/database.php
+++ b/admin/lti/database.php
@@ -258,6 +258,8 @@ array( "{$CFG->dbprefix}manifest",
     context_id          INTEGER NOT NULL,
     version             INTEGER NOT NULL,
     title               TEXT NULL,
+    -- Skinny Setup field (theme key). New course-setup features are sibling
+    -- columns, not keys inside the lessons JSON (`manifest` MEDIUMTEXT).
     theme               VARCHAR(64) NULL,
     manifest            MEDIUMTEXT NOT NULL,
     comment             TEXT NULL,

--- a/admin/users/index.php
+++ b/admin/users/index.php
@@ -19,13 +19,14 @@ if ( ! isAdmin() ) {
 }
 
 $query_parms = array();
-$searchfields = array("U.user_id", "displayname", "email", "key_title", "key_key", "U.created_at", "U.updated_at", "U.login_at", "U.login_count");
+$searchfields = array("U.user_id", "displayname", "email", "key_title", "key_key", "create_courses", "U.created_at", "U.updated_at", "U.login_at", "U.login_count");
 $sql = "SELECT U.user_id AS user_id, displayname, email, U.key_id AS key_value, key_title, key_key,
+            U.create_courses AS create_courses,
             U.login_at, U.login_count, U.created_at, U.updated_at
         FROM {$CFG->dbprefix}lti_user AS U
         LEFT JOIN {$CFG->dbprefix}lti_key AS K ON U.key_id = K.key_id
         ";
-$orderfields = array("U.user_id", "key_value", "displayname", "email", "key_key", "key_title", "U.created_at", "U.updated_at", "U.login_at", "U.login_count");
+$orderfields = array("U.user_id", "key_value", "displayname", "email", "key_key", "key_title", "create_courses", "U.created_at", "U.updated_at", "U.login_at", "U.login_count");
 
 $newsql = Table::pagedQuery($sql, $query_parms, $searchfields, $orderfields);
 // echo("<pre>\n$newsql\n</pre>\n");

--- a/admin/users/user-detail.php
+++ b/admin/users/user-detail.php
@@ -35,8 +35,9 @@ $allow_delete = true;
 $allow_edit = true;
 $where_clause = '';
 $query_fields = array();
-$fields = array("user_id", "displayname", "email", "created_at", "updated_at", "login_at", "login_count");
+$fields = array("user_id", "displayname", "email", "create_courses", "created_at", "updated_at", "login_at", "login_count");
 $from_location = "index";
+$titles = array("create_courses" => "Create courses (0 or 1)");
 
 // Handle the post data
 $row =  CrudForm::handleUpdate($tablename, $fields, $where_clause,
@@ -59,8 +60,12 @@ echo("<h1>$title</h1>\n<p>\n");
 activity data is deleted.  This is <b>not</b> a "soft delete".  A delete  on this screen truly throws away all
 of the user's data.
 </p>
+<p><b>Create courses:</b> Set to 1 to let this user add new courses from the Courses page.
+This is a user capability, not an instructor role in a course. The user may need to log in again
+after you change it.
+</p>
 <?php
-$retval = CrudForm::updateForm($row, $fields, $current, $from_location, $allow_edit, $allow_delete);
+$retval = CrudForm::updateForm($row, $fields, $current, $from_location, $allow_edit, $allow_delete, false, $titles);
 if ( is_string($retval) ) die($retval);
 echo("</p>\n");
 

--- a/assertions/route.php
+++ b/assertions/route.php
@@ -6,6 +6,7 @@ require_once('../config.php');
 use \Tsugi\Util\U;
 use \Tsugi\Core\LTIX;
 use \Tsugi\Core\Badges;
+use \Tsugi\Core\Manifest;
 use \Tsugi\UI\Lessons;
 use \Tsugi\LinkedIn\LinkedIn;
 use \Tsugi\Crypt\AesOpenSSL;
@@ -62,11 +63,11 @@ if ($first_part === 'publish') {
         $OUTPUT->footer();
         return;
     }
-    if ( ! isset($CFG->lessons) ) {
-        die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
+    if ( ! Manifest::hasCurrent() ) {
+        die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
     }
     $PDOX = LTIX::getConnection();
-    $l = new Lessons($CFG->lessons);
+    $l = Manifest::requireCurrentLessons();
     $parsed = Badges::parseAssertionId($hex_id, $l);
     if ( is_string($parsed) ) {
         http_response_code(404);
@@ -124,10 +125,7 @@ if ($first_part === 'linkedin') {
         $OUTPUT->footer();
         return;
     }
-    if ( ! isset($CFG->lessons) ) {
-        die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
-    }
-    $l = new Lessons($CFG->lessons);
+    $l = Manifest::requireCurrentLessons();
     $destination = BadgeService::linkedInDestinationUrl($guid, $share, $l);
     if ( $destination === null ) {
         http_response_code(404);
@@ -149,8 +147,8 @@ if ($first_part === 'linkedin') {
 
 // Handle fixed issuer route: /assertions/issuer.json
 if ($first_part === 'issuer.json') {
-    if ( ! isset($CFG->lessons) ) {
-        die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
+    if ( ! Manifest::hasCurrent() ) {
+        die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
     }
     $format = isset($_GET['format']) ? $_GET['format'] : 'ob2';
     if ($format === 'ob3') {
@@ -174,12 +172,12 @@ if ($first_part === 'badge' && count($path_parts) === 2) {
         $code = str_replace('?format=ob3', '', $code);
         $code = str_replace('&format=ob3', '', $code);
         
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
+        if ( ! Manifest::hasCurrent() ) {
+            die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         
         $PDOX = LTIX::getConnection();
-        $l = new Lessons($CFG->lessons);
+        $l = Manifest::requireCurrentLessons();
         
         // Find the badge by code
         $badge = null;
@@ -290,12 +288,8 @@ if (strpos($first_part, '.vc.json') !== false) {
 }
 
 // Load lesson and parse assertion
-if ( ! isset($CFG->lessons) ) {
-    die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
-}
-
 $PDOX = LTIX::getConnection();
-$l = new Lessons($CFG->lessons);
+$l = Manifest::requireCurrentLessons();
 
 $row = null;
 $pieces = null;

--- a/badges/assert.php
+++ b/badges/assert.php
@@ -4,6 +4,7 @@
 
 use \Tsugi\Util\U;
 use \Tsugi\Core\LTIX;
+use \Tsugi\Core\Manifest;
 use \Tsugi\UI\Lessons;
 
 if ( !isset($_GET['id']) ) {
@@ -13,12 +14,7 @@ if ( !isset($_GET['id']) ) {
 require_once "../config.php";
 require_once "badge-util.php";
 
-if ( ! isset($CFG->lessons) ) {
-    die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
-}
-
-// Load the Lesson
-$l = new Lessons($CFG->lessons);
+$l = Manifest::requireCurrentLessons();
 
 $PDOX = LTIX::getConnection();
 

--- a/badges/badge-info.php
+++ b/badges/badge-info.php
@@ -4,17 +4,13 @@
 
 use \Tsugi\Util\U;
 use \Tsugi\Core\LTIX;
+use \Tsugi\Core\Manifest;
 use \Tsugi\UI\Lessons;
 
 require_once "../config.php";
 require_once "badge-util.php";
 
-if ( ! isset($CFG->lessons) ) {
-    die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
-}
-
-// Load the Lesson
-$l = new Lessons($CFG->lessons);
+$l = Manifest::requireCurrentLessons();
 
 $PDOX = LTIX::getConnection();
 

--- a/badges/badge-issuer.php
+++ b/badges/badge-issuer.php
@@ -4,17 +4,13 @@
 
 use \Tsugi\Util\U;
 use \Tsugi\Core\LTIX;
+use \Tsugi\Core\Manifest;
 use \Tsugi\UI\Lessons;
 
 require_once "../config.php";
 require_once "badge-util.php";
 
-if ( ! isset($CFG->lessons) ) {
-    die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
-}
-
-// Load the Lesson
-$l = new Lessons($CFG->lessons);
+$l = Manifest::requireCurrentLessons();
 
 $PDOX = LTIX::getConnection();
 

--- a/badges/baker.php
+++ b/badges/baker.php
@@ -2,19 +2,16 @@
 
 use \Tsugi\Util\U;
 use \Tsugi\Core\LTIX;
+use \Tsugi\Core\Manifest;
 use \Tsugi\UI\Lessons;
 use \Tsugi\Image\Png;
 
 require_once "../config.php";
 require_once "badge-util.php";
 
-if ( ! isset($CFG->lessons) ) {
-    die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
-}
+$l = Manifest::requireCurrentLessons();
 
 $PDOX = LTIX::getConnection();
-// Load the Lesson
-$l = new Lessons($CFG->lessons);
 
 $url = $_SERVER['REQUEST_URI'];
 $pieces = explode('/',$url);

--- a/lib/include/setup.php
+++ b/lib/include/setup.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/tsugi_constants.php';
 // upgrade checking - don't change this unless you want to trigger
 // database upgrade messages it should be the max of all versions in
 // all database.php files.
-$CFG->dbversion = 202610010002;
+$CFG->dbversion = 202610010003;
 
 function die_with_error_log($msg, $extra=false, $prefix="DIE:") {
     error_log($prefix.' '.$msg.' '.$extra);

--- a/lib/include/setup.php
+++ b/lib/include/setup.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/tsugi_constants.php';
 // upgrade checking - don't change this unless you want to trigger
 // database upgrade messages it should be the max of all versions in
 // all database.php files.
-$CFG->dbversion = 202606100001;
+$CFG->dbversion = 202610010001;
 
 function die_with_error_log($msg, $extra=false, $prefix="DIE:") {
     error_log($prefix.' '.$msg.' '.$extra);

--- a/lib/include/setup.php
+++ b/lib/include/setup.php
@@ -10,7 +10,7 @@ require_once __DIR__ . '/tsugi_constants.php';
 // upgrade checking - don't change this unless you want to trigger
 // database upgrade messages it should be the max of all versions in
 // all database.php files.
-$CFG->dbversion = 202610010001;
+$CFG->dbversion = 202610010002;
 
 function die_with_error_log($msg, $extra=false, $prefix="DIE:") {
     error_log($prefix.' '.$msg.' '.$extra);

--- a/lib/src/Controllers/Assignments.php
+++ b/lib/src/Controllers/Assignments.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Tsugi\Grades\GradeUtil;
 use Tsugi\Core\LTIX;
+use Tsugi\Core\Manifest;
 use Tsugi\Core\Membership;
 use Tsugi\UI\Table;
 
@@ -95,11 +96,7 @@ class Assignments extends Tool {
     {
         global $CFG, $OUTPUT;
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
-        }
-
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
+        $l = Manifest::requireCurrentLessons();
 
         $allgrades = array();
         $alldates = array();
@@ -168,8 +165,8 @@ class Assignments extends Tool {
     {
         global $CFG, $OUTPUT, $PDOX;
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
+        if ( ! Manifest::hasCurrent() ) {
+            die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
 
@@ -177,7 +174,7 @@ class Assignments extends Tool {
         $context_id = U::currentContextId();
         $p = $CFG->dbprefix;
 
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
+        $l = Manifest::requireCurrentLessons();
         $assignment_items = $l->enumerateLtiAssignmentItems(true);
         $assignment_rlids = array();
         foreach ( $assignment_items as $it ) {
@@ -316,8 +313,8 @@ class Assignments extends Tool {
     {
         global $CFG, $PDOX;
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
+        if ( ! Manifest::hasCurrent() ) {
+            die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireAuth();
         $context_id = U::currentContextId();
@@ -369,13 +366,13 @@ class Assignments extends Tool {
     {
         global $CFG, $OUTPUT;
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
+        if ( ! Manifest::hasCurrent() ) {
+            die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
 
         $context_id = U::currentContextId();
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
+        $l = Manifest::requireCurrentLessons();
         $items = $l->enumerateLtiAssignmentItems(true);
         $dueMap = $this->loadDueDatesByLinkKey($context_id);
 
@@ -493,13 +490,13 @@ class Assignments extends Tool {
     {
         global $CFG, $PDOX;
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
+        if ( ! Manifest::hasCurrent() ) {
+            die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
 
         $context_id = U::currentContextId();
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
+        $l = Manifest::requireCurrentLessons();
         $allowed = array();
         foreach ( $l->enumerateLtiAssignmentItems(true) as $it ) {
             $allowed[$it['resource_link_id']] = true;
@@ -560,13 +557,13 @@ class Assignments extends Tool {
     {
         global $CFG, $PDOX;
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
+        if ( ! Manifest::hasCurrent() ) {
+            die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
 
         $context_id = U::currentContextId();
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
+        $l = Manifest::requireCurrentLessons();
         $allowed = array();
         foreach ( $l->enumerateLtiAssignmentItems(true) as $it ) {
             $allowed[$it['resource_link_id']] = true;
@@ -603,8 +600,8 @@ class Assignments extends Tool {
     {
         global $CFG, $PDOX;
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
+        if ( ! Manifest::hasCurrent() ) {
+            die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
 
@@ -622,7 +619,7 @@ class Assignments extends Tool {
             return new RedirectResponse(U::addSession($this->toolHome(self::ROUTE) . '/manage-due-dates'));
         }
 
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
+        $l = Manifest::requireCurrentLessons();
         $items = $l->enumerateLtiAssignmentItems(true);
         $dueMap = $this->loadDueDatesByLinkKey($context_id);
 
@@ -677,13 +674,13 @@ class Assignments extends Tool {
     {
         global $CFG, $PDOX;
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
+        if ( ! Manifest::hasCurrent() ) {
+            die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
 
         $context_id = U::currentContextId();
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
+        $l = Manifest::requireCurrentLessons();
         $items = $l->enumerateLtiAssignmentItems(true);
         $dueMap = $this->loadDueDatesByLinkKey($context_id);
 

--- a/lib/src/Controllers/Badges.php
+++ b/lib/src/Controllers/Badges.php
@@ -5,6 +5,7 @@ namespace Tsugi\Controllers;
 use Tsugi\Lumen\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Tsugi\Core\LTIX;
+use Tsugi\Core\Manifest;
 
 use \Tsugi\Grades\GradeUtil;
 
@@ -29,18 +30,13 @@ class Badges extends Tool {
         // Check if user is logged in
         $this->requireAuth();
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
-        }
-
         // Record learner analytics (synthetic lti_link in this context)
         $this->lmsRecordLaunchAnalytics(self::ROUTE, self::NAME);
 
         // Check if user is instructor/admin for analytics button
         $show_analytics = $this->isInstructor() || $this->isAdmin();
 
-        // Load the Lesson
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
+        $l = Manifest::requireCurrentLessons();
 
         // Load all the Grades so far
         $allgrades = array();

--- a/lib/src/Controllers/Calendar.php
+++ b/lib/src/Controllers/Calendar.php
@@ -5,6 +5,7 @@ namespace Tsugi\Controllers;
 
 use \Tsugi\Util\U;
 use Tsugi\Core\LTIX;
+use Tsugi\Core\Manifest;
 use Tsugi\Lumen\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -123,7 +124,8 @@ class Calendar extends Tool {
     {
         global $CFG;
 
-        if ( ! isset($CFG->lessons) ) {
+        $l = Manifest::currentLessons();
+        if ( ! $l ) {
             return new JsonResponse(
                 array('status' => 'error', 'detail' => 'Lessons not configured'),
                 500
@@ -138,7 +140,6 @@ class Calendar extends Tool {
 
         LTIX::getConnection();
 
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
         $items = $l->enumerateLtiAssignmentItems();
         $dueMap = GradeUtil::loadDueDatesForDisplay(U::currentContextId());
 
@@ -161,10 +162,7 @@ class Calendar extends Tool {
     {
         global $CFG, $OUTPUT;
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
-        }
-
+        $l = Manifest::requireCurrentLessons();
         $nowY = (int) date('Y');
         $nowM = (int) date('n');
         $nowD = (int) date('j');
@@ -187,7 +185,6 @@ class Calendar extends Tool {
         $daysInMonth = (int) date('t', $firstTs);
         $startDow = (int) date('w', $firstTs);
 
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
         $items = $l->enumerateLtiAssignmentItems();
         $dueMap = array();
         if ( U::currentContextId() !== 0 ) {

--- a/lib/src/Controllers/Courses.php
+++ b/lib/src/Controllers/Courses.php
@@ -347,6 +347,7 @@ class Courses extends Tool {
             <h1>Add course</h1>
             <p>Creates a new course with a starter outline. Lesson authoring for this course saves new manifest versions.</p>
             <form method="post" action="<?= htmlspecialchars($home . '/create') ?>">
+                <?= self::csrfField() ?>
                 <p>
                     <label for="course_title">Title</label><br/>
                     <input type="text" id="course_title" name="title" required maxlength="512" style="min-width: 20em;"/>
@@ -371,6 +372,9 @@ class Courses extends Tool {
         $gate = self::createGateResponse($home);
         if ( $gate ) {
             return $gate;
+        }
+        if ( ! self::checkCsrf() ) {
+            return new RedirectResponse(U::addSession($home . '/create'));
         }
 
         $title = trim((string) U::get($_POST, 'title', ''));

--- a/lib/src/Controllers/Courses.php
+++ b/lib/src/Controllers/Courses.php
@@ -373,8 +373,9 @@ class Courses extends Tool {
         if ( $gate ) {
             return $gate;
         }
-        if ( ! self::checkCsrf() ) {
-            return new RedirectResponse(U::addSession($home . '/create'));
+        $csrf = self::requireCsrf(U::addSession($home . '/create'));
+        if ( $csrf ) {
+            return $csrf;
         }
 
         $title = trim((string) U::get($_POST, 'title', ''));

--- a/lib/src/Controllers/Courses.php
+++ b/lib/src/Controllers/Courses.php
@@ -11,6 +11,7 @@ use \Tsugi\Core\LTIX;
 use \Tsugi\Core\Cache;
 use \Tsugi\Core\Context;
 use \Tsugi\Core\Manifest;
+use \Tsugi\Core\User;
 use \Tsugi\Crypt\SecureCookie;
 use \Tsugi\UI\Output;
 use \Tsugi\Util\U;
@@ -178,6 +179,7 @@ class Courses extends Tool {
         $_SESSION['context_key'] = $context_key;
         $_SESSION['context_title'] = $title;
         $_SESSION['isinstructor'] = ($role >= LTIX::ROLE_INSTRUCTOR);
+        // Do not touch User::SESSION_CREATE_COURSES — that is a user capability, not a context role.
         if ( $membership_id !== null ) {
             $_SESSION['membership_id'] = $membership_id;
         } else {
@@ -287,7 +289,9 @@ class Courses extends Tool {
         ?>
         <main class="container" id="main-content">
             <h1>Courses</h1>
+            <?php if ( self::canCreate() ) { ?>
             <p><a href="<?= htmlspecialchars($home . '/create') ?>">Add course</a></p>
+            <?php } ?>
             <?php if ( count($rows) < 1 ) { ?>
                 <p>You are not a member of any courses.</p>
             <?php } else { ?>
@@ -327,13 +331,12 @@ class Courses extends Tool {
     public static function createForm(Application $app, Request $request) {
         global $OUTPUT;
 
-        $gate = self::gateResponse();
+        $tool = new self();
+        $home = $tool->toolHome(self::ROUTE);
+        $gate = self::createGateResponse($home);
         if ( $gate ) {
             return $gate;
         }
-
-        $tool = new self();
-        $home = $tool->toolHome(self::ROUTE);
 
         $OUTPUT->header();
         $OUTPUT->bodyStart();
@@ -363,13 +366,13 @@ class Courses extends Tool {
      * POST: insert context + starter manifest, enter the course.
      */
     public static function createPost(Application $app, Request $request) {
-        $gate = self::gateResponse();
+        $tool = new self();
+        $home = $tool->toolHome(self::ROUTE);
+        $gate = self::createGateResponse($home);
         if ( $gate ) {
             return $gate;
         }
 
-        $tool = new self();
-        $home = $tool->toolHome(self::ROUTE);
         $title = trim((string) U::get($_POST, 'title', ''));
         if ( $title === '' ) {
             U::flashError(__('Title is required.'));
@@ -506,6 +509,13 @@ class Courses extends Tool {
     }
 
     /**
+     * True when the current user may mint a new site-login course.
+     */
+    public static function canCreate() {
+        return User::canCreateCourses();
+    }
+
+    /**
      * @return Response|null
      */
     public static function gateResponse() {
@@ -517,6 +527,23 @@ class Courses extends Tool {
                 'This session is an LTI launch from an LMS. Course switching is not available.',
                 403
             );
+        }
+        return null;
+    }
+
+    /**
+     * Login + Google session + create_courses (or site admin).
+     *
+     * @return Response|null
+     */
+    public static function createGateResponse($home) {
+        $gate = self::gateResponse();
+        if ( $gate ) {
+            return $gate;
+        }
+        if ( ! self::canCreate() ) {
+            U::flashError('You are not allowed to create courses.');
+            return new RedirectResponse(U::addSession($home));
         }
         return null;
     }

--- a/lib/src/Controllers/Courses.php
+++ b/lib/src/Controllers/Courses.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use \Tsugi\Core\LTIX;
 use \Tsugi\Core\Cache;
 use \Tsugi\Core\Context;
+use \Tsugi\Core\Manifest;
 use \Tsugi\Crypt\SecureCookie;
 use \Tsugi\UI\Output;
 use \Tsugi\Util\U;
@@ -27,6 +28,12 @@ class Courses extends Tool {
     public static function routes(Application $app, $prefix=self::ROUTE) {
         $app->router->get($prefix.'/json', function(Request $request) use ($app) {
             return Courses::getjson($app);
+        });
+        $app->router->get($prefix.'/create', function(Request $request) use ($app) {
+            return Courses::createForm($app, $request);
+        });
+        $app->router->post($prefix.'/create', function(Request $request) use ($app) {
+            return Courses::createPost($app, $request);
         });
         $app->router->get($prefix, function(Request $request) use ($app) {
             return Courses::index($app, $request);
@@ -132,7 +139,7 @@ class Courses extends Tool {
         $p = $CFG->dbprefix;
 
         $context_row = $PDOX->rowDie(
-            "SELECT context_id, context_key, title FROM {$p}lti_context WHERE context_id = :CID",
+            "SELECT context_id, context_key, title, manifest_id FROM {$p}lti_context WHERE context_id = :CID",
             array(':CID' => $cid)
         );
         if ( ! $context_row ) {
@@ -165,6 +172,7 @@ class Courses extends Tool {
 
         $title = isset($context_row['title']) ? $context_row['title'] : '';
         $context_key = isset($context_row['context_key']) ? $context_row['context_key'] : '';
+        $manifest_id = isset($context_row['manifest_id']) ? (int) $context_row['manifest_id'] : 0;
 
         $_SESSION['context_id'] = $cid;
         $_SESSION['context_key'] = $context_key;
@@ -190,6 +198,7 @@ class Courses extends Tool {
         }
         unset($lti['context_settings']);
         $_SESSION[$ltiKey] = $lti;
+        Manifest::rememberInSession($manifest_id);
 
         Cache::clearAllSessionCaches();
         Output::clearTopNavSession();
@@ -278,6 +287,7 @@ class Courses extends Tool {
         ?>
         <main class="container" id="main-content">
             <h1>Courses</h1>
+            <p><a href="<?= htmlspecialchars($home . '/create') ?>">Add course</a></p>
             <?php if ( count($rows) < 1 ) { ?>
                 <p>You are not a member of any courses.</p>
             <?php } else { ?>
@@ -309,6 +319,102 @@ class Courses extends Tool {
         }
 
         return new RedirectResponse(self::configuredHomeUrl());
+    }
+
+    /**
+     * Form to create a new site-login course with a starter manifest.
+     */
+    public static function createForm(Application $app, Request $request) {
+        global $OUTPUT;
+
+        $gate = self::gateResponse();
+        if ( $gate ) {
+            return $gate;
+        }
+
+        $tool = new self();
+        $home = $tool->toolHome(self::ROUTE);
+
+        $OUTPUT->header();
+        $OUTPUT->bodyStart();
+        $OUTPUT->topNav();
+        $OUTPUT->flashMessages();
+        ?>
+        <main class="container" id="main-content">
+            <h1>Add course</h1>
+            <p>Creates a new course with a starter outline. Lesson authoring for this course saves new manifest versions.</p>
+            <form method="post" action="<?= htmlspecialchars($home . '/create') ?>">
+                <p>
+                    <label for="course_title">Title</label><br/>
+                    <input type="text" id="course_title" name="title" required maxlength="512" style="min-width: 20em;"/>
+                </p>
+                <p>
+                    <button type="submit" class="btn btn-primary">Create course</button>
+                    <a href="<?= htmlspecialchars($home) ?>" class="btn btn-default">Cancel</a>
+                </p>
+            </form>
+        </main>
+        <?php
+        $OUTPUT->footer();
+        return '';
+    }
+
+    /**
+     * POST: insert context + starter manifest, enter the course.
+     */
+    public static function createPost(Application $app, Request $request) {
+        $gate = self::gateResponse();
+        if ( $gate ) {
+            return $gate;
+        }
+
+        $tool = new self();
+        $home = $tool->toolHome(self::ROUTE);
+        $title = trim((string) U::get($_POST, 'title', ''));
+        if ( $title === '' ) {
+            U::flashError(__('Title is required.'));
+            return new RedirectResponse(U::addSession($home . '/create'));
+        }
+
+        $user_id = U::loggedInUserId();
+        $key_id = self::googleKeyId();
+        $result = Manifest::createCourse($title, $user_id, $key_id);
+        if ( empty($result['ok']) ) {
+            $err = isset($result['error']) ? $result['error'] : 'Could not create course.';
+            U::flashError($err);
+            return new RedirectResponse(U::addSession($home . '/create'));
+        }
+
+        $switch = self::ensureActiveContext($result['context_id']);
+        if ( $switch !== true ) {
+            return self::switchFailedResponse($switch);
+        }
+
+        U::flashSuccess(__('Course created.'));
+        return new RedirectResponse(U::addSession($home . '/' . (int) $result['context_id']));
+    }
+
+    /**
+     * lti_key.key_id for the Google site-login consumer.
+     */
+    public static function googleKeyId() {
+        global $CFG, $PDOX;
+        $ltiKey = defined('TSUGI_SESSION_LTI') ? TSUGI_SESSION_LTI : 'lti';
+        if ( isset($_SESSION[$ltiKey]['key_id']) ) {
+            $kid = (int) $_SESSION[$ltiKey]['key_id'];
+            if ( $kid > 0 ) {
+                return $kid;
+            }
+        }
+        if ( $PDOX === null || $PDOX === false ) {
+            $PDOX = LTIX::getConnection();
+        }
+        $row = $PDOX->rowDie(
+            "SELECT key_id FROM {$CFG->dbprefix}lti_key
+             WHERE key_sha256 = :SHA LIMIT 1",
+            array(':SHA' => lti_sha256(self::GOOGLE_KEY))
+        );
+        return $row ? (int) $row['key_id'] : 0;
     }
 
     public static function nested(Application $app, Request $request, $id, $rest) {

--- a/lib/src/Controllers/Discussions.php
+++ b/lib/src/Controllers/Discussions.php
@@ -306,6 +306,10 @@ class Discussions extends Tool {
             document.addEventListener('click', function(ev) {
                 var a = ev.target && ev.target.closest ? ev.target.closest('a') : null;
                 if (!a || !hasChanges || allowLeave) return;
+                var href = a.getAttribute('href');
+                if (!href || href.charAt(0) === '#') return;
+                var target = (a.getAttribute('target') || '_self').toLowerCase();
+                if (target !== '_self') return;
                 ev.preventDefault();
                 if (window.confirm(leaveMsg + '\n\n' + <?= json_encode(__('Leave without saving?')) ?>)) {
                     allowLeave = true;

--- a/lib/src/Controllers/Discussions.php
+++ b/lib/src/Controllers/Discussions.php
@@ -6,6 +6,7 @@ namespace Tsugi\Controllers;
 use \Tsugi\Util\U;
 use Tsugi\Util\LTI;
 use Tsugi\Core\LTIX;
+use Tsugi\Core\Manifest;
 use Tsugi\Lumen\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,6 +21,10 @@ class Discussions extends Tool {
     public static function routes(Application $app, $prefix=self::ROUTE) {
         $app->router->get($prefix, 'Discussions@get');
         $app->router->get($prefix.'/', 'Discussions@get');
+        $app->router->get($prefix.'/add', 'Discussions@addForm');
+        $app->router->post($prefix.'/add', 'Discussions@addPost');
+        $app->router->get($prefix.'/reorder', 'Discussions@reorderForm');
+        $app->router->post($prefix.'/reorder', 'Discussions@reorderPost');
         $app->router->get($prefix.'/manage', 'Discussions@manage');
         $app->router->get($prefix.'/scan-fix-unread-tracking', 'Discussions@scanFixUnreadTracking');
         $app->router->get($prefix.'/expire-threads', 'Discussions@expireThreads');
@@ -39,12 +44,14 @@ class Discussions extends Tool {
     {
         global $CFG, $OUTPUT;
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
-        }
+        $l = Manifest::requireCurrentLessons();
 
-        // Load the Lesson
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
+        $add_url = null;
+        $reorder_url = null;
+        if ( Manifest::activeId() > 0 && $this->isInstructor() ) {
+            $add_url = U::addSession($this->toolHome(self::ROUTE) . '/add');
+            $reorder_url = U::addSession($this->toolHome(self::ROUTE) . '/reorder');
+        }
 
         $OUTPUT->header();
         $OUTPUT->bodyStart();
@@ -52,11 +59,327 @@ class Discussions extends Tool {
         $OUTPUT->topNav();
         $OUTPUT->flashMessages();
         echo('<main class="container" id="main-content">');
-        $l->renderDiscussions(false, $this->toolHome(self::ROUTE));
+        $l->renderDiscussions(false, $this->toolHome(self::ROUTE), $add_url, $reorder_url);
         echo('</main>');
         $OUTPUT->footer();
 
 
+    }
+
+    /**
+     * Instructor form to add a course-level discussion (manifest courses only).
+     */
+    public function addForm(Request $request)
+    {
+        global $OUTPUT;
+
+        $list_url = U::addSession($this->toolHome(self::ROUTE));
+        $gate = $this->addDiscussionGate($list_url);
+        if ( $gate ) {
+            return $gate;
+        }
+
+        $OUTPUT->header();
+        $OUTPUT->bodyStart();
+        $OUTPUT->topNav();
+        $OUTPUT->flashMessages();
+        ?>
+        <main class="container" id="main-content">
+            <h1><?= __('Add discussion') ?></h1>
+            <p><?= __('Creates a new discussion in this course and saves it as a new manifest version.') ?></p>
+            <form method="post" action="<?= htmlspecialchars(U::addSession($this->toolHome(self::ROUTE) . '/add')) ?>">
+                <p>
+                    <label for="discussion_title"><?= __('Title') ?></label><br/>
+                    <input type="text" id="discussion_title" name="title" required maxlength="512" style="min-width: 20em;"/>
+                </p>
+                <p>
+                    <button type="submit" class="btn btn-primary"><?= __('Add discussion') ?></button>
+                    <a href="<?= htmlspecialchars($list_url) ?>" class="btn btn-default"><?= __('Cancel') ?></a>
+                </p>
+            </form>
+        </main>
+        <?php
+        $OUTPUT->footer();
+        return '';
+    }
+
+    /**
+     * POST: append a top-level discussion and save a new manifest version.
+     */
+    public function addPost(Request $request)
+    {
+        $list_url = U::addSession($this->toolHome(self::ROUTE));
+        $form_url = U::addSession($this->toolHome(self::ROUTE) . '/add');
+        $gate = $this->addDiscussionGate($list_url);
+        if ( $gate ) {
+            return $gate;
+        }
+
+        $title = trim((string) U::get($_POST, 'title', ''));
+        if ( $title === '' ) {
+            U::flashError(__('Title is required.'));
+            return new RedirectResponse($form_url);
+        }
+
+        $doc = Manifest::currentDocument();
+        if ( ! $doc ) {
+            U::flashError(__('Cannot find course manifest.'));
+            return new RedirectResponse($list_url);
+        }
+        $data = json_decode($doc['json'], true);
+        if ( ! is_array($data) ) {
+            U::flashError(__('Cannot parse course manifest.'));
+            return new RedirectResponse($list_url);
+        }
+
+        try {
+            $added = Manifest::appendDiscussion($data, $title);
+            Manifest::saveNewVersion(
+                U::currentContextId(),
+                $added['data'],
+                U::loggedInUserId(),
+                'Add discussion'
+            );
+        } catch ( \InvalidArgumentException $e ) {
+            U::flashError($e->getMessage());
+            return new RedirectResponse($form_url);
+        } catch ( \Exception $e ) {
+            U::flashError(__('Failed to save discussion.'));
+            return new RedirectResponse($form_url);
+        }
+
+        U::flashSuccess(__('Discussion added.'));
+        return new RedirectResponse($list_url);
+    }
+
+    /**
+     * Instructor page to drag-reorder discussions (manifest courses only).
+     */
+    public function reorderForm(Request $request)
+    {
+        global $OUTPUT;
+
+        $list_url = U::addSession($this->toolHome(self::ROUTE));
+        $gate = $this->addDiscussionGate($list_url);
+        if ( $gate ) {
+            return $gate;
+        }
+
+        $l = Manifest::requireCurrentLessons();
+        $discussions = $l->flattenedDiscussions();
+        if ( count($discussions) < 2 ) {
+            U::flashError(__('You need at least two discussions to reorder.'));
+            return new RedirectResponse($list_url);
+        }
+
+        $save_url = U::addSession($this->toolHome(self::ROUTE) . '/reorder');
+
+        $OUTPUT->header();
+        $OUTPUT->bodyStart();
+        $OUTPUT->topNav();
+        $OUTPUT->flashMessages();
+        ?>
+        <style>
+.tsugi-discussions-sortable { list-style: none; padding-left: 0; max-width: 40em; }
+.tsugi-discussions-sortable > li {
+    display: flex; align-items: center; gap: 0.5em;
+    padding: 0.6em 0.75em; margin-bottom: 0.4em;
+    background: #fff; border: 1px solid #ddd; border-radius: 3px;
+}
+.tsugi-discussion-drag-handle { cursor: grab; color: #999; padding: 0.15em 0.45em; user-select: none; font-size: 1.2em; }
+.tsugi-discussion-drag-handle:hover { color: #333; }
+.tsugi-discussion-drag-handle:active { cursor: grabbing; }
+.tsugi-discussions-sortable .ui-sortable-placeholder {
+    height: 2.5em; border: 2px dashed #007bff; visibility: visible !important;
+    background: #f0f8ff;
+}
+.tsugi-reorder-save-bar {
+    position: fixed; bottom: 0; left: 0; right: 0;
+    background: #333; color: #fff; padding: 15px 20px;
+    display: flex; justify-content: space-between; align-items: center;
+    box-shadow: 0 -2px 10px rgba(0,0,0,0.2); z-index: 1000;
+}
+.tsugi-reorder-save-bar.hidden { display: none; }
+.tsugi-reorder-save-bar .actions { display: flex; gap: 10px; }
+        </style>
+        <main class="container" id="main-content" style="padding-bottom: 5em;">
+            <p><a href="<?= htmlspecialchars($list_url) ?>" class="btn btn-default btn-sm tsugi-reorder-leave"><?= __('Back to Discussions') ?></a></p>
+            <h1><?= __('Reorder discussions') ?></h1>
+            <p><?= __('Drag the handle to change the order, then save. Nothing is stored until you save.') ?></p>
+            <ul id="tsugi-reorder-list" class="tsugi-discussions-sortable">
+                <?php foreach ( $discussions as $discussion ) {
+                    $rid = isset($discussion->resource_link_id) ? (string) $discussion->resource_link_id : '';
+                    $title = isset($discussion->title) ? (string) $discussion->title : $rid;
+                    if ( $rid === '' ) {
+                        continue;
+                    }
+                ?>
+                <li data-resource-link-id="<?= htmlspecialchars($rid) ?>">
+                    <span class="tsugi-discussion-drag-handle" title="<?= htmlspecialchars(__('Drag to reorder')) ?>" aria-label="<?= htmlspecialchars(__('Drag to reorder')) ?>">&#8942;</span>
+                    <span><?= htmlspecialchars($title) ?></span>
+                </li>
+                <?php } ?>
+            </ul>
+            <p>
+                <button type="button" id="tsugi-reorder-save" class="btn btn-success" disabled><?= __('Save') ?></button>
+                <a href="<?= htmlspecialchars($list_url) ?>" class="btn btn-default tsugi-reorder-leave"><?= __('Discard') ?></a>
+            </p>
+        </main>
+        <div id="tsugi-reorder-save-bar" class="tsugi-reorder-save-bar hidden">
+            <div><?= __('You have unsaved order changes') ?></div>
+            <div class="actions">
+                <button type="button" id="tsugi-reorder-save-bar-btn" class="btn btn-success"><?= __('Save') ?></button>
+                <a href="<?= htmlspecialchars($list_url) ?>" class="btn btn-default tsugi-reorder-leave"><?= __('Discard') ?></a>
+            </div>
+        </div>
+        <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            var hasChanges = false;
+            var allowLeave = false;
+            var saveUrl = <?= json_encode($save_url) ?>;
+            var listUrl = <?= json_encode($list_url) ?>;
+            var leaveMsg = <?= json_encode(__('Please save before you navigate, or discard your changes.')) ?>;
+
+            function markChanged() {
+                hasChanges = true;
+                var save = document.getElementById('tsugi-reorder-save');
+                if (save) save.disabled = false;
+                var bar = document.getElementById('tsugi-reorder-save-bar');
+                if (bar) bar.classList.remove('hidden');
+            }
+
+            function collectOrder() {
+                var order = [];
+                document.querySelectorAll('#tsugi-reorder-list > li[data-resource-link-id]').forEach(function(li) {
+                    var id = li.getAttribute('data-resource-link-id');
+                    if (id) order.push(id);
+                });
+                return order;
+            }
+
+            function saveOrder() {
+                if (!hasChanges) return;
+                var btn = document.getElementById('tsugi-reorder-save');
+                var barBtn = document.getElementById('tsugi-reorder-save-bar-btn');
+                if (btn) btn.disabled = true;
+                if (barBtn) barBtn.disabled = true;
+                jQuery.post(saveUrl, { order: collectOrder() })
+                    .done(function(data) {
+                        allowLeave = true;
+                        hasChanges = false;
+                        window.location = (data && data.redirect) ? data.redirect : listUrl;
+                    })
+                    .fail(function(xhr) {
+                        if (btn) btn.disabled = false;
+                        if (barBtn) barBtn.disabled = false;
+                        var msg = 'Could not save discussion order.';
+                        try {
+                            var body = JSON.parse(xhr.responseText);
+                            if (body && body.error) msg = body.error;
+                        } catch (e) {}
+                        alert(msg);
+                    });
+            }
+
+            if (typeof jQuery !== 'undefined' && jQuery.fn.sortable) {
+                jQuery('#tsugi-reorder-list').sortable({
+                    handle: '.tsugi-discussion-drag-handle',
+                    items: '> li',
+                    placeholder: 'ui-sortable-placeholder',
+                    tolerance: 'pointer',
+                    update: function() { markChanged(); }
+                });
+            }
+
+            var save = document.getElementById('tsugi-reorder-save');
+            if (save) save.addEventListener('click', saveOrder);
+            var barBtn = document.getElementById('tsugi-reorder-save-bar-btn');
+            if (barBtn) barBtn.addEventListener('click', saveOrder);
+
+            window.addEventListener('beforeunload', function(ev) {
+                if (!hasChanges || allowLeave) return;
+                ev.preventDefault();
+                ev.returnValue = leaveMsg;
+                return leaveMsg;
+            });
+
+            document.addEventListener('click', function(ev) {
+                var a = ev.target && ev.target.closest ? ev.target.closest('a') : null;
+                if (!a || !hasChanges || allowLeave) return;
+                ev.preventDefault();
+                if (window.confirm(leaveMsg + '\n\n' + <?= json_encode(__('Leave without saving?')) ?>)) {
+                    allowLeave = true;
+                    window.location = a.href;
+                }
+            }, true);
+        });
+        </script>
+        <?php
+        $OUTPUT->footer();
+        return '';
+    }
+
+    /**
+     * POST: persist a new catalog order as a manifest version (AJAX).
+     */
+    public function reorderPost(Request $request)
+    {
+        if ( Manifest::activeId() < 1 ) {
+            return new JsonResponse(array('success' => false, 'error' => 'Manifest required'), 403);
+        }
+        if ( ! $this->isInstructor() ) {
+            return new JsonResponse(array('success' => false, 'error' => 'Instructor required'), 403);
+        }
+
+        $order = U::get($_POST, 'order', array());
+        if ( is_string($order) ) {
+            $decoded = json_decode($order, true);
+            $order = is_array($decoded) ? $decoded : array();
+        }
+        if ( ! is_array($order) ) {
+            return new JsonResponse(array('success' => false, 'error' => 'Order is required'), 400);
+        }
+
+        $doc = Manifest::currentDocument();
+        if ( ! $doc ) {
+            return new JsonResponse(array('success' => false, 'error' => 'Cannot find course manifest'), 500);
+        }
+        $data = json_decode($doc['json'], true);
+        if ( ! is_array($data) ) {
+            return new JsonResponse(array('success' => false, 'error' => 'Cannot parse course manifest'), 500);
+        }
+
+        try {
+            $data = Manifest::reorderDiscussions($data, $order);
+            Manifest::saveNewVersion(
+                U::currentContextId(),
+                $data,
+                U::loggedInUserId(),
+                'Reorder discussions'
+            );
+        } catch ( \InvalidArgumentException $e ) {
+            return new JsonResponse(array('success' => false, 'error' => $e->getMessage()), 400);
+        } catch ( \Exception $e ) {
+            return new JsonResponse(array('success' => false, 'error' => 'Failed to save order'), 500);
+        }
+
+        U::flashSuccess(__('Discussion order saved.'));
+        return new JsonResponse(array(
+            'success' => true,
+            'redirect' => U::addSession($this->toolHome(self::ROUTE)),
+        ));
+    }
+
+    /**
+     * @return RedirectResponse|null
+     */
+    private function addDiscussionGate($list_url) {
+        if ( Manifest::activeId() < 1 ) {
+            U::flashError(__('Adding discussions is only available for courses with a manifest.'));
+            return new RedirectResponse($list_url);
+        }
+        $this->requireInstructor($list_url);
+        return null;
     }
 
     public static function launch(Application $app, $anchor=null)
@@ -68,15 +391,9 @@ class Discussions extends Tool {
         $redirect_path = U::addSession(self::determineParentPath(self::ROUTE));
         if ( $redirect_path == '') $redirect_path = '/';
 
-        if ( ! isset($CFG->lessons) ) {
-            $app->tsugiFlashError(__('Cannot find lessons.json ($CFG->lessons)'));
-            return new RedirectResponse($redirect_path);
-        }
-
-        /// Load the Lesson
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
+        $l = Manifest::currentLessons();
         if ( ! $l ) {
-            $app->tsugiFlashError(__('Cannot load lessons.'));
+            $app->tsugiFlashError(__('Cannot find lessons.json ($CFG->lessons) or an active course manifest'));
             return new RedirectResponse($redirect_path);
         }
 

--- a/lib/src/Controllers/Files.php
+++ b/lib/src/Controllers/Files.php
@@ -355,8 +355,9 @@ class Files extends Tool {
             U::flashError('Invalid folder path');
             return new RedirectResponse($redirect);
         }
-        if ( ! $this->checkCsrf() ) {
-            return new RedirectResponse($redirect);
+        $csrf = $this->requireCsrf($redirect);
+        if ( $csrf ) {
+            return $csrf;
         }
 
         if ( BlobUtil::emptyPost() ) {
@@ -414,8 +415,9 @@ class Files extends Tool {
             U::flashError('Invalid folder path');
             return new RedirectResponse($redirect);
         }
-        if ( ! $this->checkCsrf() ) {
-            return new RedirectResponse($redirect);
+        $csrf = $this->requireCsrf($redirect);
+        if ( $csrf ) {
+            return $csrf;
         }
 
         $name = trim(U::get($_POST, 'name', ''));
@@ -459,8 +461,9 @@ class Files extends Tool {
 
         $folder = $this->postedFolder();
         $redirect = $this->folderUrl($folder === false ? '' : $folder);
-        if ( ! $this->checkCsrf() ) {
-            return new RedirectResponse($redirect);
+        $csrf = $this->requireCsrf($redirect);
+        if ( $csrf ) {
+            return $csrf;
         }
 
         $file_id = (int)$id;

--- a/lib/src/Controllers/Files.php
+++ b/lib/src/Controllers/Files.php
@@ -869,29 +869,6 @@ class Files extends Tool {
         return $out;
     }
 
-    private function csrfField()
-    {
-        $token = $_SESSION['CSRF_TOKEN'] ?? '';
-        if ( $token === '' ) {
-            return '';
-        }
-        return '<input type="hidden" name="CSRF_TOKEN" value="'.htmlspecialchars($token).'">';
-    }
-
-    private function checkCsrf()
-    {
-        $token = $_SESSION['CSRF_TOKEN'] ?? '';
-        if ( $token === '' ) {
-            return true;
-        }
-        $posted = U::get($_POST, 'CSRF_TOKEN', '');
-        if ( $posted !== $token ) {
-            U::flashError('Missing or invalid CSRF token');
-            return false;
-        }
-        return true;
-    }
-
     private function formatStamp($stamp)
     {
         if ( empty($stamp) || $stamp === '1970-01-02 00:00:00' ) {

--- a/lib/src/Controllers/LaunchController.php
+++ b/lib/src/Controllers/LaunchController.php
@@ -3,6 +3,7 @@
 namespace Tsugi\Controllers;
 
 use Tsugi\Util\U;
+use Tsugi\Core\Manifest;
 use Tsugi\Lumen\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -50,12 +51,12 @@ class LaunchController extends Tool {
             $redirect_path = '/';
         }
 
-        if ( ! isset($CFG->lessons) ) {
-            $app->tsugiFlashError(__('Cannot find lessons.json ($CFG->lessons)'));
+        $l = Manifest::currentLessons();
+        if ( ! $l ) {
+            $app->tsugiFlashError(__('Cannot find lessons.json ($CFG->lessons) or an active course manifest'));
             return new RedirectResponse($redirect_path);
         }
 
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
         $lti = $l->getLtiByRlid($resource_link_id);
         if ( ! $lti ) {
             $app->tsugiFlashError(__('Cannot find lti resource link id'));

--- a/lib/src/Controllers/Lessons.php
+++ b/lib/src/Controllers/Lessons.php
@@ -4,6 +4,7 @@ namespace Tsugi\Controllers;
 
 use Tsugi\Util\U;
 use Tsugi\Core\LTIX;
+use Tsugi\Core\Manifest;
 use Tsugi\Lumen\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -20,6 +21,8 @@ class Lessons extends Tool {
         $app->router->get($prefix.'/', 'Lessons@get');
         $app->router->get('/'.self::REDIRECT, 'Lessons@get');
         // Author route must precede {anchor} so "_author" is not captured as anchor
+        $app->router->get($prefix.'/_author/export', 'Lessons@authorExport');
+        $app->router->post($prefix.'/_author/import', 'Lessons@authorImport');
         $app->router->get($prefix.'/_author', 'Lessons@author');
         $app->router->post($prefix.'/_author', 'Lessons@authorPost');
         $app->router->get($prefix.'/{anchor}', 'Lessons@get');
@@ -32,10 +35,11 @@ class Lessons extends Tool {
 
     public function get(Request $request, $anchor=null)
     {
-        global $CFG, $OUTPUT;
+        global $OUTPUT;
 
-        if ( ! isset($CFG->lessons) ) {
-            die_with_error_log('Cannot find lessons.json ($CFG->lessons)');
+        $l = Manifest::currentLessons($anchor);
+        if ( ! $l ) {
+            die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
 
         Tool::applyGradeRefreshAfterLaunchReturn();
@@ -49,7 +53,6 @@ class Lessons extends Tool {
             }
         }
 
-        $l = new \Tsugi\UI\Lessons($CFG->lessons, $anchor);
         $l->toolHome = $this->toolHome(self::ROUTE);
 
         // If we have an anchor in the path but it doesn't exist, redirect to /lessons
@@ -64,8 +67,8 @@ class Lessons extends Tool {
         $menu = false;
         $OUTPUT->topNav();
         $OUTPUT->flashMessages();
-        // Show Author link for instructors when authoring is allowed
-        if ( $CFG->canAuthor() && $this->isInstructor() ) {
+        // Show Author link for instructors of a manifest course, or file authoring when enabled
+        if ( $this->canAuthorLessons() && $this->isInstructor() ) {
             $author_url = U::addSession($this->toolHome(self::ROUTE) . '/_author');
             echo('<span style="position: fixed; right: 10px; top: 75px; z-index: 999; background-color: white; padding: 4px 8px; border-radius: 4px; box-shadow: 0 1px 3px rgba(0,0,0,0.2);">');
             echo('<a href="'.htmlspecialchars($author_url).'" class="btn btn-default btn-sm"><i class="fa fa-pencil" aria-hidden="true"></i> '.__('Author').'</a>');
@@ -89,36 +92,44 @@ class Lessons extends Tool {
     }
 
     /**
-     * Lesson authoring interface - localhost and instructor only
+     * File authoring stays behind canAuthor(); manifest courses allow any instructor.
+     */
+    private function canAuthorLessons() {
+        global $CFG;
+        if ( Manifest::activeId() > 0 ) {
+            return true;
+        }
+        return $CFG->canAuthor();
+    }
+
+    /**
+     * Lesson authoring interface - instructor; file-backed also requires canAuthor()
      */
     public function author(Request $request)
     {
         global $CFG, $OUTPUT, $PDOX;
 
-        if ( ! $CFG->canAuthor() ) {
+        if ( ! $this->canAuthorLessons() ) {
             return new Response('Lesson authoring is not enabled', 403);
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
 
-        if ( ! isset($CFG->lessons) ) {
-            return new Response('Cannot find lessons file ($CFG->lessons)', 500);
-        }
-        $lessons_file = $CFG->lessons;
-
-        if ( ! file_exists($lessons_file) ) {
-            return new Response('Lessons file not found: ' . htmlspecialchars($lessons_file), 404);
+        $doc = Manifest::currentDocument();
+        if ( ! $doc ) {
+            return new Response('Cannot find lessons file or course manifest', 500);
         }
 
         LTIX::getConnection();
-        $lessons_json = file_get_contents($lessons_file);
-        $lessons_data = json_decode($lessons_json, true);
+        $lessons_data = json_decode($doc['json'], true);
         if ( json_last_error() !== JSON_ERROR_NONE ) {
             return new Response('Error parsing JSON: ' . json_last_error_msg(), 500);
         }
 
         $lessons_title = htmlspecialchars($lessons_data['title'] ?? 'Untitled');
-        $lessons_file_escaped = htmlspecialchars($lessons_file);
+        $lessons_file_escaped = htmlspecialchars($doc['label']);
         $lessons_json = json_encode($lessons_data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $export_url = U::addSession($this->toolHome(self::ROUTE) . '/_author/export');
+        $import_url = U::addSession($this->toolHome(self::ROUTE) . '/_author/import');
 
         $lessons_url = U::addSession($this->toolHome(self::ROUTE));
         $OUTPUT->header();
@@ -142,17 +153,10 @@ class Lessons extends Tool {
      */
     public function authorPost(Request $request)
     {
-        global $CFG;
-
-        if ( ! $CFG->canAuthor() ) {
+        if ( ! $this->canAuthorLessons() ) {
             return new Response(json_encode(['success' => false, 'error' => 'Not allowed']), 403, ['Content-Type' => 'application/json']);
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
-
-        if ( ! isset($CFG->lessons) ) {
-            return new Response(json_encode(['success' => false, 'error' => 'Lessons not configured']), 500, ['Content-Type' => 'application/json']);
-        }
-        $lessons_file = $CFG->lessons;
 
         $action = U::get($_POST, 'action');
         if ( $action !== 'save' ) {
@@ -165,17 +169,134 @@ class Lessons extends Tool {
         }
 
         $lessons_data = json_decode($data, true);
-        if ( json_last_error() !== JSON_ERROR_NONE ) {
+        if ( json_last_error() !== JSON_ERROR_NONE || ! is_array($lessons_data) ) {
             return new Response(json_encode(['success' => false, 'error' => 'Invalid JSON: ' . json_last_error_msg()]), 400, ['Content-Type' => 'application/json']);
         }
 
-        $json_output = json_encode($lessons_data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        $result = @file_put_contents($lessons_file, $json_output);
-        if ( $result === false ) {
-            return new Response(json_encode(['success' => false, 'error' => 'Failed to write file']), 500, ['Content-Type' => 'application/json']);
+        $err = $this->persistLessonsArray($lessons_data, 'Author save');
+        if ( $err !== null ) {
+            return new Response(json_encode(['success' => false, 'error' => $err]), 400, ['Content-Type' => 'application/json']);
         }
 
-        return new Response(json_encode(['success' => true, 'message' => 'File saved successfully']), 200, ['Content-Type' => 'application/json']);
+        $message = Manifest::activeId() > 0 ? 'Manifest saved' : 'File saved successfully';
+        return new Response(json_encode(['success' => true, 'message' => $message]), 200, ['Content-Type' => 'application/json']);
+    }
+
+    /**
+     * Download the last saved lessons.json (manifest row or $CFG->lessons file).
+     */
+    public function authorExport(Request $request)
+    {
+        if ( ! $this->canAuthorLessons() ) {
+            return new Response('Lesson authoring is not enabled', 403);
+        }
+        $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
+
+        $doc = Manifest::currentDocument();
+        if ( ! $doc ) {
+            return new Response('Cannot find lessons file or course manifest', 500);
+        }
+
+        $decoded = json_decode($doc['json'], true);
+        $title = is_array($decoded) && isset($decoded['title']) ? $decoded['title'] : 'lessons';
+        $version = isset($doc['version']) ? (int) $doc['version'] : 0;
+        $filename = Manifest::exportFilename($title, $version);
+        $filename = str_replace(array('\\', '"'), '', $filename);
+
+        return new Response($doc['json'], 200, array(
+            'Content-Type' => 'application/json; charset=utf-8',
+            'Content-Disposition' => 'attachment; filename="'.$filename.'"',
+            'Cache-Control' => 'no-store',
+        ));
+    }
+
+    /**
+     * Upload a lessons.json file and save it as a new manifest version (or replace the file).
+     */
+    public function authorImport(Request $request)
+    {
+        $author_url = U::addSession($this->toolHome(self::ROUTE) . '/_author');
+        if ( ! $this->canAuthorLessons() ) {
+            return new Response('Lesson authoring is not enabled', 403);
+        }
+        $this->requireInstructor($author_url);
+
+        if ( empty($_FILES['file']) || ! is_array($_FILES['file']) ) {
+            U::flashError(__('No file uploaded.'));
+            return new RedirectResponse($author_url);
+        }
+        $file = $_FILES['file'];
+        if ( ($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK ) {
+            U::flashError(__('Upload failed.'));
+            return new RedirectResponse($author_url);
+        }
+        $size = isset($file['size']) ? (int) $file['size'] : 0;
+        if ( $size < 1 || $size > 5 * 1024 * 1024 ) {
+            U::flashError(__('File must be between 1 byte and 5 MB.'));
+            return new RedirectResponse($author_url);
+        }
+        $tmp = isset($file['tmp_name']) ? $file['tmp_name'] : '';
+        if ( $tmp === '' || ! is_uploaded_file($tmp) ) {
+            U::flashError(__('Upload failed.'));
+            return new RedirectResponse($author_url);
+        }
+
+        $raw = file_get_contents($tmp);
+        $lessons_data = json_decode($raw, true);
+        if ( json_last_error() !== JSON_ERROR_NONE || ! is_array($lessons_data) ) {
+            U::flashError(__('Invalid JSON: ') . json_last_error_msg());
+            return new RedirectResponse($author_url);
+        }
+
+        $err = $this->persistLessonsArray($lessons_data, 'Import');
+        if ( $err !== null ) {
+            U::flashError($err);
+            return new RedirectResponse($author_url);
+        }
+
+        U::flashSuccess(__('Imported lessons.json.'));
+        return new RedirectResponse($author_url);
+    }
+
+    /**
+     * Validate and persist a decoded lessons document. Returns an error message or null.
+     *
+     * @param array<string, mixed> $lessons_data
+     * @return string|null
+     */
+    private function persistLessonsArray($lessons_data, $comment) {
+        global $CFG;
+
+        $json = Manifest::encode($lessons_data);
+        $err = Manifest::validateJson($json);
+        if ( $err !== null ) {
+            return $err;
+        }
+
+        $manifest_id = Manifest::activeId();
+        if ( $manifest_id > 0 ) {
+            $context_id = U::currentContextId();
+            if ( $context_id < 1 ) {
+                return 'No course context';
+            }
+            try {
+                Manifest::saveNewVersion($context_id, $lessons_data, U::loggedInUserId(), $comment);
+            } catch ( \InvalidArgumentException $e ) {
+                return $e->getMessage();
+            } catch ( \Exception $e ) {
+                return 'Failed to save manifest';
+            }
+            return null;
+        }
+
+        if ( ! isset($CFG->lessons) ) {
+            return 'Lessons not configured';
+        }
+        $result = @file_put_contents($CFG->lessons, $json);
+        if ( $result === false ) {
+            return 'Failed to write file';
+        }
+        return null;
     }
 
     public static function launch(Application $app, $anchor=null)
@@ -186,14 +307,9 @@ class Lessons extends Tool {
         $redirect_path = U::addSession(self::determineParentPath(self::ROUTE));
         if ( $redirect_path == '') $redirect_path = '/';
 
-        if ( ! isset($CFG->lessons) ) {
-            $app->tsugiFlashError(__('Cannot find lessons.json ($CFG->lessons)'));
-            return new RedirectResponse($redirect_path);
-        }
-
-        $l = new \Tsugi\UI\Lessons($CFG->lessons);
+        $l = Manifest::currentLessons();
         if ( ! $l ) {
-            $app->tsugiFlashError(__('Cannot load lessons.'));
+            $app->tsugiFlashError(__('Cannot find lessons.json ($CFG->lessons) or an active course manifest'));
             return new RedirectResponse($redirect_path);
         }
 

--- a/lib/src/Controllers/Setup.php
+++ b/lib/src/Controllers/Setup.php
@@ -88,6 +88,7 @@ class Setup extends Tool {
             <h1><?= __('Setup') ?></h1>
             <p><?= __('Theme is stored with each manifest version. New courses start with the site default until you pick one.') ?></p>
             <form method="post" action="<?= htmlspecialchars($save_url) ?>">
+                <?= self::csrfField() ?>
                 <?php include __DIR__ . '/templates/Setup/theme_picker.inc.php'; ?>
                 <p>
                     <button type="submit" class="btn btn-primary"><?= __('Save theme') ?></button>
@@ -106,6 +107,9 @@ class Setup extends Tool {
         $gate = $this->setupGate();
         if ( $gate ) {
             return $gate;
+        }
+        if ( ! self::checkCsrf() ) {
+            return new RedirectResponse($setup_url);
         }
 
         $posted = U::get($_POST, 'theme', '');

--- a/lib/src/Controllers/Setup.php
+++ b/lib/src/Controllers/Setup.php
@@ -108,8 +108,9 @@ class Setup extends Tool {
         if ( $gate ) {
             return $gate;
         }
-        if ( ! self::checkCsrf() ) {
-            return new RedirectResponse($setup_url);
+        $csrf = self::requireCsrf($setup_url);
+        if ( $csrf ) {
+            return $csrf;
         }
 
         $posted = U::get($_POST, 'theme', '');

--- a/lib/src/Controllers/Setup.php
+++ b/lib/src/Controllers/Setup.php
@@ -4,6 +4,7 @@ namespace Tsugi\Controllers;
 
 use Tsugi\Util\U;
 use Tsugi\Core\Manifest;
+use Tsugi\Core\Membership;
 use Tsugi\Lumen\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -16,8 +17,10 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
  * …) follow the same pattern. File-based $CFG->lessons sites keep using
  * the site $CFG->theme; this page is instructor + manifest only.
  *
- * Parent menus:
- * rtrim($CFG->apphome, '/') . Courses::toolPathPrefix() . '/setup'
+ * Parent menus (instructors of a manifest course only):
+ * if ( \Tsugi\Controllers\Setup::showInMenu() ) {
+ *     $set->addLink('Setup', rtrim($CFG->apphome, '/') . Courses::toolPathPrefix() . '/setup');
+ * }
  */
 class Setup extends Tool {
 
@@ -31,6 +34,34 @@ class Setup extends Tool {
         $app->router->get('/'.self::REDIRECT, 'Setup@get');
         $app->router->post($prefix, 'Setup@post');
         $app->router->post($prefix.'/', 'Setup@post');
+    }
+
+    /**
+     * True when the current user may open Setup (instructor/admin of a manifest course).
+     *
+     * Use this in parent buildmenu.php so students never see the link.
+     */
+    public static function showInMenu() {
+        if ( Manifest::activeId() < 1 ) {
+            return false;
+        }
+        return self::currentUserIsInstructor();
+    }
+
+    /**
+     * Instructor or site admin for the current context (membership role, not $USER->instructor).
+     */
+    private static function currentUserIsInstructor() {
+        $context_id = U::currentContextId();
+        $user_id = U::loggedInUserId();
+        if ( ! $context_id || ! $user_id ) {
+            return false;
+        }
+        if ( isset($_SESSION['admin']) && $_SESSION['admin'] == 'yes' ) {
+            return true;
+        }
+        $m = Membership::ensureInSession($context_id, $user_id);
+        return $m->isInstructor();
     }
 
     public function get(Request $request)
@@ -122,11 +153,11 @@ class Setup extends Tool {
      */
     private function setupGate() {
         $home = U::addSession(self::configuredHomeUrl());
+        $this->requireInstructor($home);
         if ( Manifest::activeId() < 1 ) {
             U::flashError(__('Setup is only available for courses with a manifest.'));
             return new RedirectResponse($home);
         }
-        $this->requireInstructor($home);
         return null;
     }
 }

--- a/lib/src/Controllers/Setup.php
+++ b/lib/src/Controllers/Setup.php
@@ -11,7 +11,9 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 /**
  * Course setup for manifest-backed courses.
  *
- * First field is the course theme. File-based $CFG->lessons sites keep using
+ * Setup fields are independent columns on the manifest row, not part of
+ * the legacy lessons JSON. Theme is the first; later fields (navigation,
+ * …) follow the same pattern. File-based $CFG->lessons sites keep using
  * the site $CFG->theme; this page is instructor + manifest only.
  *
  * Parent menus:

--- a/lib/src/Controllers/Setup.php
+++ b/lib/src/Controllers/Setup.php
@@ -45,6 +45,7 @@ class Setup extends Tool {
 
         $theme_current = Manifest::currentThemeKey();
         $theme_palettes = Manifest::palettes();
+        $theme_site_primary = Manifest::siteDefaultPrimary();
         $save_url = $setup_url;
 
         $OUTPUT->header();
@@ -59,6 +60,7 @@ class Setup extends Tool {
                 <?php include __DIR__ . '/templates/Setup/theme_picker.inc.php'; ?>
                 <p>
                     <button type="submit" class="btn btn-primary"><?= __('Save theme') ?></button>
+                    <a href="<?= htmlspecialchars($save_url) ?>" class="btn btn-default"><?= __('Cancel') ?></a>
                 </p>
             </form>
         </main>

--- a/lib/src/Controllers/Setup.php
+++ b/lib/src/Controllers/Setup.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tsugi\Controllers;
+
+use Tsugi\Util\U;
+use Tsugi\Core\Manifest;
+use Tsugi\Lumen\Application;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Course setup for manifest-backed courses.
+ *
+ * First field is the course theme. File-based $CFG->lessons sites keep using
+ * the site $CFG->theme; this page is instructor + manifest only.
+ *
+ * Parent menus:
+ * rtrim($CFG->apphome, '/') . Courses::toolPathPrefix() . '/setup'
+ */
+class Setup extends Tool {
+
+    const ROUTE = '/setup';
+    const NAME = 'Setup';
+    const REDIRECT = 'tsugi_controllers_setup';
+
+    public static function routes(Application $app, $prefix=self::ROUTE) {
+        $app->router->get($prefix, 'Setup@get');
+        $app->router->get($prefix.'/', 'Setup@get');
+        $app->router->get('/'.self::REDIRECT, 'Setup@get');
+        $app->router->post($prefix, 'Setup@post');
+        $app->router->post($prefix.'/', 'Setup@post');
+    }
+
+    public function get(Request $request)
+    {
+        global $OUTPUT;
+
+        $setup_url = U::addSession($this->toolHome(self::ROUTE));
+        $gate = $this->setupGate();
+        if ( $gate ) {
+            return $gate;
+        }
+
+        $theme_current = Manifest::currentThemeKey();
+        $theme_palettes = Manifest::palettes();
+        $save_url = $setup_url;
+
+        $OUTPUT->header();
+        $OUTPUT->bodyStart();
+        $OUTPUT->topNav();
+        $OUTPUT->flashMessages();
+        ?>
+        <main class="container" id="main-content">
+            <h1><?= __('Setup') ?></h1>
+            <p><?= __('Theme is stored with each manifest version. New courses start with the site default until you pick one.') ?></p>
+            <form method="post" action="<?= htmlspecialchars($save_url) ?>">
+                <?php include __DIR__ . '/templates/Setup/theme_picker.inc.php'; ?>
+                <p>
+                    <button type="submit" class="btn btn-primary"><?= __('Save theme') ?></button>
+                </p>
+            </form>
+        </main>
+        <?php
+        $OUTPUT->footer();
+        return '';
+    }
+
+    public function post(Request $request)
+    {
+        $setup_url = U::addSession($this->toolHome(self::ROUTE));
+        $gate = $this->setupGate();
+        if ( $gate ) {
+            return $gate;
+        }
+
+        $posted = U::get($_POST, 'theme', '');
+        $norm = Manifest::normalizeThemeKey($posted);
+        if ( $norm === false ) {
+            U::flashError(__('Unknown theme.'));
+            return new RedirectResponse($setup_url);
+        }
+
+        $doc = Manifest::currentDocument();
+        if ( ! $doc ) {
+            U::flashError(__('Cannot load course manifest.'));
+            return new RedirectResponse($setup_url);
+        }
+        $decoded = json_decode($doc['json'], true);
+        if ( ! is_array($decoded) ) {
+            U::flashError(__('Invalid manifest JSON.'));
+            return new RedirectResponse($setup_url);
+        }
+
+        $context_id = U::currentContextId();
+        $store = $norm === null ? '' : $norm;
+        try {
+            Manifest::saveNewVersion(
+                $context_id,
+                $decoded,
+                U::loggedInUserId(),
+                'Set theme',
+                $store
+            );
+        } catch ( \InvalidArgumentException $e ) {
+            U::flashError($e->getMessage());
+            return new RedirectResponse($setup_url);
+        } catch ( \Exception $e ) {
+            U::flashError(__('Failed to save theme.'));
+            return new RedirectResponse($setup_url);
+        }
+
+        U::flashSuccess(__('Theme saved.'));
+        return new RedirectResponse($setup_url);
+    }
+
+    /**
+     * @return RedirectResponse|null
+     */
+    private function setupGate() {
+        $home = U::addSession(self::configuredHomeUrl());
+        if ( Manifest::activeId() < 1 ) {
+            U::flashError(__('Setup is only available for courses with a manifest.'));
+            return new RedirectResponse($home);
+        }
+        $this->requireInstructor($home);
+        return null;
+    }
+}

--- a/lib/src/Controllers/Tool.php
+++ b/lib/src/Controllers/Tool.php
@@ -69,19 +69,47 @@ abstract class Tool {
     }
 
     /**
-     * True when POST CSRF_TOKEN matches the session token (fail closed).
+     * True when POST CSRF_TOKEN (or X-CSRF-TOKEN) matches the session token.
+     *
+     * @return bool
+     */
+    public static function csrfOk() {
+        $token = $_SESSION['CSRF_TOKEN'] ?? '';
+        if ( ! is_string($token) || $token === '' ) {
+            return false;
+        }
+        $posted = U::get($_POST, 'CSRF_TOKEN', '');
+        if ( is_string($posted) && $posted !== '' && hash_equals($token, $posted) ) {
+            return true;
+        }
+        $header = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? $_SERVER['HTTP_X_CSRFTOKEN'] ?? '';
+        return is_string($header) && $header !== '' && hash_equals($token, $header);
+    }
+
+    /**
+     * True when the CSRF token is valid (fail closed). Flashes on failure.
      *
      * @return bool
      */
     public static function checkCsrf() {
-        $token = $_SESSION['CSRF_TOKEN'] ?? '';
-        $posted = U::get($_POST, 'CSRF_TOKEN', '');
-        if ( ! is_string($token) || $token === '' || ! is_string($posted) || $posted === ''
-                || ! hash_equals($token, $posted) ) {
-            U::flashError('Missing or invalid CSRF token');
-            return false;
+        if ( self::csrfOk() ) {
+            return true;
         }
-        return true;
+        U::flashError('Missing or invalid CSRF token');
+        return false;
+    }
+
+    /**
+     * Redirect back to $redirect when the CSRF token is missing or invalid.
+     *
+     * @param string $redirect
+     * @return RedirectResponse|null Null when the token is valid.
+     */
+    public static function requireCsrf($redirect) {
+        if ( self::checkCsrf() ) {
+            return null;
+        }
+        return new RedirectResponse($redirect);
     }
 
     /**

--- a/lib/src/Controllers/Tool.php
+++ b/lib/src/Controllers/Tool.php
@@ -55,6 +55,36 @@ abstract class Tool {
     }
 
     /**
+     * Hidden CSRF_TOKEN input for cookie-session HTML forms that POST to Tsugi.
+     *
+     * Mints a session token if the current session does not have one yet
+     * (Google site login historically did not set CSRF_TOKEN; LTI launch does).
+     * Do not use this on LTI launches or signed webhooks.
+     *
+     * @return string
+     */
+    public static function csrfField() {
+        $token = LTIX::ensureCsrfToken();
+        return '<input type="hidden" name="CSRF_TOKEN" value="'.htmlspecialchars($token).'">';
+    }
+
+    /**
+     * True when POST CSRF_TOKEN matches the session token (fail closed).
+     *
+     * @return bool
+     */
+    public static function checkCsrf() {
+        $token = $_SESSION['CSRF_TOKEN'] ?? '';
+        $posted = U::get($_POST, 'CSRF_TOKEN', '');
+        if ( ! is_string($token) || $token === '' || ! is_string($posted) || $posted === ''
+                || ! hash_equals($token, $posted) ) {
+            U::flashError('Missing or invalid CSRF token');
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Require LTI consumer session fields needed to sign an outbound LTI 1.1 launch.
      *
      * @return RedirectResponse|null Null if session is sufficient; redirect with flash otherwise.

--- a/lib/src/Controllers/Tsugi.php
+++ b/lib/src/Controllers/Tsugi.php
@@ -32,6 +32,7 @@ class Tsugi extends \Tsugi\Lumen\Application {
             \Tsugi\Controllers\Files::routes($this);
             \Tsugi\Controllers\Grades::routes($this);
             \Tsugi\Controllers\Lessons::routes($this);
+            \Tsugi\Controllers\Setup::routes($this);
             \Tsugi\Controllers\Labs::routes($this);
             \Tsugi\Controllers\LaunchController::routes($this);
             \Tsugi\Controllers\Login::routes($this);

--- a/lib/src/Controllers/templates/Lessons/author_interface.inc.php
+++ b/lib/src/Controllers/templates/Lessons/author_interface.inc.php
@@ -9,6 +9,8 @@
  * - $lessons_title: HTML-escaped lessons title
  * - $lessons_file_escaped: HTML-escaped lessons file path
  * - $lessons_json: JSON-encoded lessons data for JavaScript
+ * - $export_url: session-bearing URL to download the saved document
+ * - $import_url: session-bearing URL to POST an uploaded lessons.json
  */
 ?>
 <style>
@@ -33,6 +35,23 @@
 .lesson-author-header .info {
     color: #666;
     font-size: 14px;
+}
+
+.author-io {
+    margin-top: 12px;
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.author-io form {
+    display: inline;
+    margin: 0;
+}
+
+.author-io input[type="file"] {
+    display: none;
 }
 
 .module-container {
@@ -554,6 +573,13 @@
         <div class="info">
             <?= $lessons_file_escaped ?>
         </div>
+        <div class="author-io">
+            <a class="btn" href="<?= htmlspecialchars($export_url) ?>"><?= __('Export lessons.json') ?></a>
+            <form id="lessons-import-form" onsubmit="return false;">
+                <input type="file" id="lessons-import-file" name="file" accept=".json,application/json" />
+                <button type="button" class="btn" onclick="document.getElementById('lessons-import-file').click()"><?= __('Import lessons.json') ?></button>
+            </form>
+        </div>
     </div>
 
     <div id="modules-container">
@@ -626,6 +652,58 @@ $(document).ready(function() {
     migrateFCPXToReference();
     renderModules();
     setupSortable();
+
+    var importFile = document.getElementById('lessons-import-file');
+    if (importFile) {
+        importFile.addEventListener('change', function() {
+            if (!this.files || !this.files.length) return;
+            var warn = hasChanges
+                ? 'You have unsaved changes. Loading this file will replace the editor contents. Continue?'
+                : 'Load this file into the editor? You will need to Save Changes to store it.';
+            if (!confirm(warn)) {
+                this.value = '';
+                return;
+            }
+            var file = this.files[0];
+            var input = this;
+            var reader = new FileReader();
+            reader.onload = function(ev) {
+                var parsed;
+                try {
+                    parsed = JSON.parse(ev.target.result);
+                } catch (err) {
+                    alert('Invalid JSON: ' + (err && err.message ? err.message : 'could not parse file'));
+                    input.value = '';
+                    return;
+                }
+                if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                    alert('lessons.json must be a JSON object.');
+                    input.value = '';
+                    return;
+                }
+                if (!parsed.modules || !Array.isArray(parsed.modules)) {
+                    alert('lessons.json must have a modules array.');
+                    input.value = '';
+                    return;
+                }
+                lessonsData = parsed;
+                migrateFCPXToReference();
+                var titleEl = document.querySelector('.lesson-author-header h1');
+                if (titleEl) {
+                    titleEl.textContent = lessonsData.title || 'Untitled';
+                }
+                renderModules();
+                setupSortable();
+                markChanged();
+                input.value = '';
+            };
+            reader.onerror = function() {
+                alert('Could not read that file.');
+                input.value = '';
+            };
+            reader.readAsText(file);
+        });
+    }
     
     // Track changes
     $(document).on('input change', 'input, textarea, select', function() {

--- a/lib/src/Controllers/templates/Setup/theme_picker.inc.php
+++ b/lib/src/Controllers/templates/Setup/theme_picker.inc.php
@@ -2,7 +2,8 @@
 /**
  * Theme radio swatches.
  *
- * Expected: $theme_palettes (Manifest::palettes()), $theme_current (string key or '').
+ * Expected: $theme_palettes (Manifest::palettes()), $theme_current (string key or ''),
+ * $theme_site_primary (hex for the Site default swatch).
  */
 if ( ! isset($theme_palettes) || ! is_array($theme_palettes) ) {
     $theme_palettes = array();
@@ -11,6 +12,9 @@ if ( ! isset($theme_current) ) {
     $theme_current = '';
 }
 $theme_current = is_string($theme_current) ? $theme_current : '';
+if ( ! isset($theme_site_primary) || ! is_string($theme_site_primary) || $theme_site_primary === '' ) {
+    $theme_site_primary = '#0D47A1';
+}
 ?>
 <style>
 .theme-picker {
@@ -37,7 +41,6 @@ $theme_current = is_string($theme_current) ? $theme_current : '';
     opacity: 0;
     pointer-events: none;
 }
-.theme-swatch.is-selected,
 .theme-swatch:has(input:checked) {
     border-color: #333;
     box-shadow: 0 0 0 1px #333;
@@ -55,9 +58,9 @@ $theme_current = is_string($theme_current) ? $theme_current : '';
 </style>
 <fieldset class="theme-picker" id="theme-picker">
     <legend><?= __('Theme') ?></legend>
-    <label class="theme-swatch<?= $theme_current === '' ? ' is-selected' : '' ?>">
+    <label class="theme-swatch">
         <input type="radio" name="theme" value=""<?= $theme_current === '' ? ' checked' : '' ?> />
-        <span class="theme-swatch-bar" style="background: linear-gradient(90deg, #ccc, #eee);"></span>
+        <span class="theme-swatch-bar" style="background: <?= htmlspecialchars($theme_site_primary) ?>;"></span>
         <span class="theme-swatch-label"><?= __('Site default') ?></span>
     </label>
     <?php foreach ( $theme_palettes as $key => $palette ) {
@@ -65,7 +68,7 @@ $theme_current = is_string($theme_current) ? $theme_current : '';
         $primary = isset($palette['primary']) ? $palette['primary'] : '#999999';
         $selected = ($theme_current === $key);
         ?>
-        <label class="theme-swatch<?= $selected ? ' is-selected' : '' ?>">
+        <label class="theme-swatch">
             <input type="radio" name="theme" value="<?= htmlspecialchars($key) ?>"<?= $selected ? ' checked' : '' ?> />
             <span class="theme-swatch-bar" style="background: <?= htmlspecialchars($primary) ?>;"></span>
             <span class="theme-swatch-label"><?= htmlspecialchars($label) ?></span>

--- a/lib/src/Controllers/templates/Setup/theme_picker.inc.php
+++ b/lib/src/Controllers/templates/Setup/theme_picker.inc.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Theme radio swatches.
+ *
+ * Expected: $theme_palettes (Manifest::palettes()), $theme_current (string key or '').
+ */
+if ( ! isset($theme_palettes) || ! is_array($theme_palettes) ) {
+    $theme_palettes = array();
+}
+if ( ! isset($theme_current) ) {
+    $theme_current = '';
+}
+$theme_current = is_string($theme_current) ? $theme_current : '';
+?>
+<style>
+.theme-picker {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin: 16px 0 20px 0;
+}
+.theme-swatch {
+    display: flex;
+    flex-direction: column;
+    width: 140px;
+    margin: 0;
+    padding: 0;
+    border: 2px solid #ddd;
+    border-radius: 6px;
+    overflow: hidden;
+    cursor: pointer;
+    background: #fff;
+    font-weight: normal;
+}
+.theme-swatch input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+.theme-swatch.is-selected,
+.theme-swatch:has(input:checked) {
+    border-color: #333;
+    box-shadow: 0 0 0 1px #333;
+}
+.theme-swatch-bar {
+    display: block;
+    height: 36px;
+}
+.theme-swatch-label {
+    display: block;
+    padding: 8px 10px;
+    font-size: 13px;
+    color: #333;
+}
+</style>
+<fieldset class="theme-picker" id="theme-picker">
+    <legend><?= __('Theme') ?></legend>
+    <label class="theme-swatch<?= $theme_current === '' ? ' is-selected' : '' ?>">
+        <input type="radio" name="theme" value=""<?= $theme_current === '' ? ' checked' : '' ?> />
+        <span class="theme-swatch-bar" style="background: linear-gradient(90deg, #ccc, #eee);"></span>
+        <span class="theme-swatch-label"><?= __('Site default') ?></span>
+    </label>
+    <?php foreach ( $theme_palettes as $key => $palette ) {
+        $label = isset($palette['label']) ? $palette['label'] : $key;
+        $primary = isset($palette['primary']) ? $palette['primary'] : '#999999';
+        $selected = ($theme_current === $key);
+        ?>
+        <label class="theme-swatch<?= $selected ? ' is-selected' : '' ?>">
+            <input type="radio" name="theme" value="<?= htmlspecialchars($key) ?>"<?= $selected ? ' checked' : '' ?> />
+            <span class="theme-swatch-bar" style="background: <?= htmlspecialchars($primary) ?>;"></span>
+            <span class="theme-swatch-label"><?= htmlspecialchars($label) ?></span>
+        </label>
+    <?php } ?>
+</fieldset>

--- a/lib/src/Core/LTIX.php
+++ b/lib/src/Core/LTIX.php
@@ -2682,6 +2682,7 @@ class LTIX {
         $_SESSION['profile_id'] = $row['profile_id'];
         $_SESSION['user_key'] = $row['user_key'];
         $_SESSION['avatar'] = $row['user_image'];
+        User::rememberCreateCourses($row['user_id']);
         if ( isset($row['key_key']) ) {
             $_SESSION['oauth_consumer_key'] = $row['key_key'];
         }

--- a/lib/src/Core/LTIX.php
+++ b/lib/src/Core/LTIX.php
@@ -647,6 +647,8 @@ class LTIX {
         // Put the information into the row variable and put row into session
         $_SESSION[TSUGI_SESSION_LTI] = $row;
         $_SESSION[TSUGI_SESSION_LTI_POST] = $request_data;
+        // Always set/clear so a file-based launch cannot keep a leftover sandbox manifest_id.
+        \Tsugi\Core\Manifest::rememberInSession($row['manifest_id'] ?? 0);
 
         if ( isset($_SERVER['HTTP_USER_AGENT']) ) {
             $_SESSION['HTTP_USER_AGENT'] = $_SERVER['HTTP_USER_AGENT'];
@@ -1172,7 +1174,7 @@ class LTIX {
             c.lineitems_url AS lineitems_url, c.memberships_url AS memberships_url,
             c.lti13_lineitems AS lti13_lineitems, c.lti13_membership_url AS lti13_membership_url,
             c.lti13_context_groups_url AS lti13_context_groups_url,
-            c.settings AS context_settings,
+            c.settings AS context_settings, c.manifest_id AS manifest_id,
             l.link_id, l.path AS link_path, l.title AS link_title, l.settings AS link_settings, l.settings_url AS link_settings_url,
             l.lti13_lineitem AS lti13_lineitem, l.settings AS link_settings,
             u.user_id, u.displayname AS user_displayname, u.email AS user_email, u.user_key AS user_key, u.image AS user_image,

--- a/lib/src/Core/LTIX.php
+++ b/lib/src/Core/LTIX.php
@@ -670,7 +670,7 @@ class LTIX {
         $browser_mark = self::getBrowserMark();
         $_SESSION['BROWSER_MARK'] = $browser_mark;
 
-        $_SESSION['CSRF_TOKEN'] = uniqid();
+        self::ensureCsrfToken(true);
 
         // Save this to make sure the user does not wander unless we launched from the root
         $scp = $CFG->getScriptPath();
@@ -2577,6 +2577,21 @@ class LTIX {
     private static function checkReferer() {
         global $CFG;
         return isset($_SERVER['HTTP_REFERER']) && strpos($_SERVER['HTTP_REFERER'],$CFG->wwwroot) === 0 ;
+    }
+
+    /**
+     * Session CSRF token for same-origin HTML forms (not LTI launches or signed webhooks).
+     *
+     * @param bool $rotate When true, always mint a new token (login / LTI launch).
+     * @return string
+     */
+    public static function ensureCsrfToken($rotate = false) {
+        $token = $_SESSION['CSRF_TOKEN'] ?? '';
+        if ( $rotate || ! is_string($token) || $token === '' ) {
+            $token = bin2hex(random_bytes(16));
+            $_SESSION['CSRF_TOKEN'] = $token;
+        }
+        return $token;
     }
 
     // Returns true for a good CSRF and false if we could not verify it

--- a/lib/src/Core/Manifest.php
+++ b/lib/src/Core/Manifest.php
@@ -7,17 +7,23 @@ use \Tsugi\Util\U;
 use \Tsugi\UI\Lessons;
 
 /**
- * Versioned course-manifest JSON, keyed by immutable manifest_id.
+ * Versioned course manifest, keyed by immutable manifest_id.
  *
  * File-based $CFG->lessons sites are unchanged: a context with no
- * manifest_id keeps using the file. New courses store the same JSON
- * shape in the manifest table; each save inserts a new row and points
- * lti_context.manifest_id at it.
+ * manifest_id keeps using the file. New courses get a manifest row;
+ * each save inserts a new row and points lti_context.manifest_id at it.
  *
- * The PHP session holds only the integer manifest_id. The JSON is loaded
- * on demand via {@see self::loadJson()} and cached in Memcached (MCache)
- * under a key derived from manifest_id, not context_id. Tsugi\Core\Cache
- * is session-based and must not be used for this document.
+ * The lessons JSON (column `manifest`) is the legacy pre-manifest document:
+ * the same shape as lessons.json (modules, discussions, badges, …). Do not
+ * grow that blob with new course-setup features. New Setup fields are
+ * independent columns on this row (theme is the first: VARCHAR key, not
+ * palette JSON). Navigation and later Setup work follow that pattern.
+ *
+ * The PHP session holds only the integer manifest_id. The immutable row
+ * (lessons JSON plus sibling columns) is loaded on demand and cached in
+ * Memcached (MCache) under a key derived from manifest_id, not context_id.
+ * Tsugi\Core\Cache is session-based and must not be used for this document.
+ * Older cache entries that stored a JSON string only are still accepted.
  *
  * Tools that auto-populate from lessons.json (store import, CC export,
  * peer-grade inherit, Autograder, Google Classroom, admin install repos)
@@ -552,26 +558,33 @@ class Manifest {
         if ( isset(self::$requestJson[$id]) && is_string(self::$requestJson[$id]) ) {
             return self::$requestJson[$id];
         }
+        if ( isset(self::$requestRows[$id]) ) {
+            $json = self::$requestRows[$id]['manifest'] ?? '';
+            if ( is_string($json) && $json !== '' ) {
+                self::$requestJson[$id] = $json;
+                return $json;
+            }
+        }
 
         $cache = self::mcache();
-        if ( $cache && method_exists($cache, 'isEnabled') && $cache->isEnabled() ) {
+        if ( $cache && method_exists($cache, 'isEnabled') && $cache->isEnabled()
+                && method_exists($cache, 'get') ) {
             $cached = $cache->get(self::cacheKey($id));
+            $row = self::rowFromCacheValue($cached);
+            if ( is_array($row) ) {
+                if ( ! isset($row['manifest_id']) ) {
+                    $row['manifest_id'] = $id;
+                }
+                self::rememberRequest($id, $row);
+                return $row['manifest'];
+            }
             if ( is_string($cached) && strlen($cached) > 0 ) {
                 self::$requestJson[$id] = $cached;
                 return $cached;
             }
         }
 
-        $json = self::loadJsonFromDatabase($id);
-        if ( ! is_string($json) || strlen($json) < 1 ) {
-            return false;
-        }
-        self::$requestJson[$id] = $json;
-        if ( $cache && method_exists($cache, 'isEnabled') && $cache->isEnabled()
-                && method_exists($cache, 'set') ) {
-            $cache->set(self::cacheKey($id), $json, self::CACHE_TTL);
-        }
-        return $json;
+        return self::loadJsonFromDatabase($id);
     }
 
     /**
@@ -737,12 +750,16 @@ class Manifest {
         );
         $manifest_id = (int) $PDOX->lastInsertId();
         self::setActive($cid, $manifest_id);
-        self::$requestJson[$manifest_id] = $json;
-        $cache = self::mcache();
-        if ( $cache && method_exists($cache, 'isEnabled') && $cache->isEnabled()
-                && method_exists($cache, 'set') ) {
-            $cache->set(self::cacheKey($manifest_id), $json, self::CACHE_TTL);
-        }
+        self::rememberCachedRow(array(
+            'manifest_id' => $manifest_id,
+            'context_id' => $cid,
+            'version' => $version,
+            'title' => $title,
+            'theme' => $themeToStore,
+            'manifest' => $json,
+            'comment' => $comment,
+            'user_id' => $uid,
+        ));
         return $manifest_id;
     }
 
@@ -855,6 +872,21 @@ class Manifest {
         if ( isset(self::$requestRows[$id]) ) {
             return self::$requestRows[$id];
         }
+
+        $cache = self::mcache();
+        if ( $cache && method_exists($cache, 'isEnabled') && $cache->isEnabled()
+                && method_exists($cache, 'get') ) {
+            $cached = $cache->get(self::cacheKey($id));
+            $row = self::rowFromCacheValue($cached);
+            if ( is_array($row) ) {
+                if ( ! isset($row['manifest_id']) ) {
+                    $row['manifest_id'] = $id;
+                }
+                self::rememberRequest($id, $row);
+                return $row;
+            }
+        }
+
         $PDOX = LTIX::getConnection();
         $p = $CFG->dbprefix;
         $row = $PDOX->rowDie(
@@ -865,8 +897,54 @@ class Manifest {
         if ( ! is_array($row) ) {
             return false;
         }
-        self::$requestRows[$id] = $row;
+        self::rememberCachedRow($row);
         return $row;
+    }
+
+    /**
+     * Cached MCache payload is a row array; older entries were a JSON string.
+     *
+     * @param mixed $cached
+     * @return array<string, mixed>|false
+     */
+    private static function rowFromCacheValue($cached) {
+        if ( ! is_array($cached) ) {
+            return false;
+        }
+        $json = $cached['manifest'] ?? '';
+        if ( ! is_string($json) || $json === '' ) {
+            return false;
+        }
+        return $cached;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private static function rememberRequest($id, $row) {
+        self::$requestRows[$id] = $row;
+        $json = $row['manifest'] ?? '';
+        if ( is_string($json) && $json !== '' ) {
+            self::$requestJson[$id] = $json;
+        }
+    }
+
+    /**
+     * Request memo plus MCache. Payload is the immutable row (JSON + theme).
+     *
+     * @param array<string, mixed> $row
+     */
+    private static function rememberCachedRow($row) {
+        $id = (int) ($row['manifest_id'] ?? 0);
+        if ( $id < 1 ) {
+            return;
+        }
+        self::rememberRequest($id, $row);
+        $cache = self::mcache();
+        if ( $cache && method_exists($cache, 'isEnabled') && $cache->isEnabled()
+                && method_exists($cache, 'set') ) {
+            $cache->set(self::cacheKey($id), $row, self::CACHE_TTL);
+        }
     }
 
     /**

--- a/lib/src/Core/Manifest.php
+++ b/lib/src/Core/Manifest.php
@@ -1,0 +1,725 @@
+<?php
+
+namespace Tsugi\Core;
+
+use \Tsugi\Util\MCache;
+use \Tsugi\Util\U;
+use \Tsugi\UI\Lessons;
+
+/**
+ * Versioned course-manifest JSON, keyed by immutable manifest_id.
+ *
+ * File-based $CFG->lessons sites are unchanged: a context with no
+ * manifest_id keeps using the file. New courses store the same JSON
+ * shape in the manifest table; each save inserts a new row and points
+ * lti_context.manifest_id at it.
+ *
+ * The PHP session holds only the integer manifest_id. The JSON is loaded
+ * on demand via {@see self::loadJson()} and cached in Memcached (MCache)
+ * under a key derived from manifest_id, not context_id. Tsugi\Core\Cache
+ * is session-based and must not be used for this document.
+ *
+ * Tools that auto-populate from lessons.json (store import, CC export,
+ * peer-grade inherit, Autograder, Google Classroom, admin install repos)
+ * stay on $CFG->lessons for now. Manifest-course authoring should use LTI
+ * custom / resource-link settings instead; that wiring is deferred.
+ *
+ * Every new version is test-loaded with Lessons::tryFromJson() before insert.
+ * Authoring can export/import a lessons.json file; import is the same save path.
+ *
+ * Outbound LTI launches from the lessons/discussions catalog (file vs manifest
+ * resource_link_id, custom, launch URL) are a later pass. Do not mix those
+ * behaviors in casually; parent-site launches and new-course launches will
+ * need an explicit design.
+ */
+class Manifest {
+
+    /** Memcached TTL in seconds; 0 means no expiry. Rows are immutable. */
+    const CACHE_TTL = 86400;
+
+    /** @var array<int, string> Request-local JSON strings keyed by manifest_id. */
+    private static $requestJson = array();
+
+    /** @var MCache|object|null Injected or lazy MCache; false means "constructed empty". */
+    private static $mcache = null;
+
+    /**
+     * Drop request-local memoization (tests / identity switch).
+     */
+    public static function resetRequestCache() {
+        self::$requestJson = array();
+    }
+
+    /**
+     * Replace the MCache used by loadJson (tests). Pass null to rebuild from $CFG.
+     *
+     * @param MCache|object|null $mcache
+     */
+    public static function setMCache($mcache) {
+        self::$mcache = $mcache;
+    }
+
+    /**
+     * Memcached key for an immutable manifest row.
+     */
+    public static function cacheKey($manifest_id) {
+        global $CFG;
+        $id = (int) $manifest_id;
+        $prefix = 'tsugi';
+        if ( is_object($CFG) && method_exists($CFG, 'serverPrefix') ) {
+            $p = $CFG->serverPrefix();
+            if ( is_string($p) && strlen($p) > 0 ) {
+                $prefix = $p;
+            }
+        }
+        return $prefix . ':manifest:' . $id;
+    }
+
+    /**
+     * Minimal valid lessons.json-shaped document for a new course.
+     *
+     * @return array<string, mixed>
+     */
+    public static function starter($title) {
+        $title = is_string($title) ? trim($title) : '';
+        if ( $title === '' ) {
+            $title = 'Untitled Course';
+        }
+        return array(
+            'title' => $title,
+            'description' => '',
+            'count' => true,
+            'required_modules' => array(),
+            'discussions' => array(),
+            'badges' => array(),
+            'modules' => array(
+                array(
+                    'title' => 'Week 1',
+                    'anchor' => 'week-1',
+                    'description' => '',
+                    'items' => array(),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Encode manifest JSON the same way file authoring does.
+     *
+     * @param array<string, mixed>|object $data
+     */
+    public static function encode($data) {
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
+     * Test-load a JSON string as Lessons. Returns an error message, or null if valid.
+     *
+     * @return string|null
+     */
+    public static function validateJson($json) {
+        if ( ! is_string($json) || trim($json) === '' ) {
+            return 'Document is empty';
+        }
+        $loaded = Lessons::tryFromJson($json);
+        if ( $loaded instanceof Lessons ) {
+            return null;
+        }
+        if ( is_string($loaded) && strlen($loaded) > 0 ) {
+            return $loaded;
+        }
+        return 'Invalid lessons document';
+    }
+
+    /**
+     * Download filename for an exported lessons.json.
+     *
+     * Includes V{n} when a manifest version is known, and the export date.
+     */
+    public static function exportFilename($title, $version = 0, $date = null) {
+        $title = is_string($title) ? $title : '';
+        $slug = preg_replace('/[^A-Za-z0-9]+/', '-', $title);
+        $slug = trim($slug, '-');
+        $version = (int) $version;
+        if ( ! is_string($date) || $date === '' ) {
+            $date = date('Y-m-d');
+        }
+        $date = preg_replace('/[^0-9-]/', '', $date);
+        $parts = array();
+        if ( $slug !== '' ) {
+            $parts[] = $slug;
+        } else {
+            $parts[] = 'lessons';
+        }
+        if ( $version > 0 ) {
+            $parts[] = 'V' . $version;
+        }
+        if ( $date !== '' ) {
+            $parts[] = $date;
+        }
+        if ( $slug !== '' ) {
+            return implode('-', $parts) . '-lessons.json';
+        }
+        return implode('-', $parts) . '.json';
+    }
+
+    /**
+     * Append a course-level discussion to a decoded lessons document.
+     *
+     * @param array<string, mixed> $data
+     * @return array{data: array<string, mixed>, resource_link_id: string}
+     */
+    public static function appendDiscussion($data, $title, $launch = 'mod/tdiscus/') {
+        if ( ! is_array($data) ) {
+            throw new \InvalidArgumentException('Document must be an array');
+        }
+        $title = is_string($title) ? trim($title) : '';
+        if ( $title === '' ) {
+            throw new \InvalidArgumentException('Title is required');
+        }
+        $launch = is_string($launch) && trim($launch) !== '' ? trim($launch) : 'mod/tdiscus/';
+        if ( ! isset($data['discussions']) || ! is_array($data['discussions']) ) {
+            $data['discussions'] = array();
+        }
+        $used = self::collectResourceLinkIds($data);
+        $base = self::discussionRlidBase($title);
+        $rlid = $base;
+        $n = 2;
+        while ( isset($used[$rlid]) ) {
+            $rlid = $base . '_' . $n;
+            $n++;
+            if ( $n > 50 ) {
+                $rlid = $base . '_' . bin2hex(random_bytes(3));
+                break;
+            }
+        }
+        $data['discussions'][] = array(
+            'title' => $title,
+            'launch' => $launch,
+            'resource_link_id' => $rlid,
+        );
+        if ( isset($data['discussion_order']) && is_array($data['discussion_order']) ) {
+            $data['discussion_order'][] = $rlid;
+        }
+        return array('data' => $data, 'resource_link_id' => $rlid);
+    }
+
+    /**
+     * Reorder course discussions to match a list of resource_link_id values.
+     *
+     * Sets discussion_order (catalog display) and permutes the top-level
+     * discussions array. Unknown ids are ignored; discussions not in the
+     * list keep their relative order at the end.
+     *
+     * @param array<string, mixed> $data
+     * @param array<int, mixed> $ordered_rlids
+     * @return array<string, mixed>
+     */
+    public static function reorderDiscussions($data, $ordered_rlids) {
+        if ( ! is_array($data) ) {
+            throw new \InvalidArgumentException('Document must be an array');
+        }
+        if ( ! is_array($ordered_rlids) ) {
+            throw new \InvalidArgumentException('Order is required');
+        }
+        $seen = array();
+        $order = array();
+        foreach ( $ordered_rlids as $id ) {
+            if ( is_int($id) || is_float($id) ) {
+                $id = (string) $id;
+            }
+            if ( ! is_string($id) ) {
+                continue;
+            }
+            $id = trim($id);
+            if ( $id === '' || isset($seen[$id]) ) {
+                continue;
+            }
+            $seen[$id] = true;
+            $order[] = $id;
+        }
+        if ( count($order) < 1 ) {
+            throw new \InvalidArgumentException('Order is required');
+        }
+        $data['discussion_order'] = $order;
+
+        if ( isset($data['discussions']) && is_array($data['discussions']) ) {
+            $by_id = array();
+            $no_id = array();
+            foreach ( $data['discussions'] as $d ) {
+                if ( ! is_array($d) ) {
+                    continue;
+                }
+                $rid = isset($d['resource_link_id']) && is_string($d['resource_link_id'])
+                    ? $d['resource_link_id'] : '';
+                if ( $rid === '' ) {
+                    $no_id[] = $d;
+                    continue;
+                }
+                if ( ! isset($by_id[$rid]) ) {
+                    $by_id[$rid] = $d;
+                }
+            }
+            $new = array();
+            foreach ( $order as $rid ) {
+                if ( isset($by_id[$rid]) ) {
+                    $new[] = $by_id[$rid];
+                    unset($by_id[$rid]);
+                }
+            }
+            foreach ( $by_id as $d ) {
+                $new[] = $d;
+            }
+            foreach ( $no_id as $d ) {
+                $new[] = $d;
+            }
+            $data['discussions'] = $new;
+        }
+        return $data;
+    }
+
+    /**
+     * resource_link_id values already used in a decoded lessons document.
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, true>
+     */
+    public static function collectResourceLinkIds($data) {
+        $ids = array();
+        if ( ! is_array($data) ) {
+            return $ids;
+        }
+        self::collectRlidsFromList(isset($data['discussions']) ? $data['discussions'] : null, $ids);
+        self::collectRlidsFromList(isset($data['launches']) ? $data['launches'] : null, $ids);
+        if ( isset($data['modules']) && is_array($data['modules']) ) {
+            foreach ( $data['modules'] as $mod ) {
+                if ( ! is_array($mod) ) {
+                    continue;
+                }
+                self::collectRlidsFromList(isset($mod['lti']) ? $mod['lti'] : null, $ids);
+                self::collectRlidsFromList(isset($mod['discussions']) ? $mod['discussions'] : null, $ids);
+                self::collectRlidsFromList(isset($mod['items']) ? $mod['items'] : null, $ids);
+            }
+        }
+        return $ids;
+    }
+
+    /**
+     * @param mixed $list
+     * @param array<string, true> $ids
+     */
+    private static function collectRlidsFromList($list, &$ids) {
+        if ( ! is_array($list) ) {
+            return;
+        }
+        foreach ( $list as $item ) {
+            if ( is_array($item) && isset($item['resource_link_id'])
+                    && is_string($item['resource_link_id']) && $item['resource_link_id'] !== '' ) {
+                $ids[$item['resource_link_id']] = true;
+            }
+        }
+    }
+
+    private static function discussionRlidBase($title) {
+        $slug = strtolower($title);
+        $slug = preg_replace('/[^a-z0-9]+/', '_', $slug);
+        $slug = trim($slug, '_');
+        if ( $slug === '' ) {
+            $slug = 'topic';
+        }
+        if ( strlen($slug) > 40 ) {
+            $slug = substr($slug, 0, 40);
+            $slug = rtrim($slug, '_');
+        }
+        return 'discussion_' . $slug;
+    }
+
+    /**
+     * Active manifest_id for this request (session only; 0 if file-backed or none).
+     */
+    public static function activeId() {
+        $ltiKey = defined('TSUGI_SESSION_LTI') ? TSUGI_SESSION_LTI : 'lti';
+        if ( isset($_SESSION[$ltiKey]) && is_array($_SESSION[$ltiKey]) ) {
+            $id = self::positiveId($_SESSION[$ltiKey]['manifest_id'] ?? 0);
+            if ( $id > 0 ) {
+                return $id;
+            }
+        }
+        return self::positiveId($_SESSION['manifest_id'] ?? 0);
+    }
+
+    /**
+     * Copy manifest_id into the session LTI blob (integer only).
+     */
+    public static function rememberInSession($manifest_id) {
+        $id = (int) $manifest_id;
+        $ltiKey = defined('TSUGI_SESSION_LTI') ? TSUGI_SESSION_LTI : 'lti';
+        if ( $id < 1 ) {
+            unset($_SESSION['manifest_id']);
+            if ( isset($_SESSION[$ltiKey]) && is_array($_SESSION[$ltiKey]) ) {
+                unset($_SESSION[$ltiKey]['manifest_id']);
+            }
+            return;
+        }
+        $_SESSION['manifest_id'] = $id;
+        if ( ! isset($_SESSION[$ltiKey]) || ! is_array($_SESSION[$ltiKey]) ) {
+            $_SESSION[$ltiKey] = array();
+        }
+        $_SESSION[$ltiKey]['manifest_id'] = $id;
+    }
+
+    /**
+     * JSON string for a manifest_id, or false if missing.
+     *
+     * Lookup: request memo, then MCache, then database. Does not parse into Lessons.
+     *
+     * @return string|false
+     */
+    public static function loadJson($manifest_id) {
+        $id = (int) $manifest_id;
+        if ( $id < 1 ) {
+            return false;
+        }
+        if ( isset(self::$requestJson[$id]) && is_string(self::$requestJson[$id]) ) {
+            return self::$requestJson[$id];
+        }
+
+        $cache = self::mcache();
+        if ( $cache && method_exists($cache, 'isEnabled') && $cache->isEnabled() ) {
+            $cached = $cache->get(self::cacheKey($id));
+            if ( is_string($cached) && strlen($cached) > 0 ) {
+                self::$requestJson[$id] = $cached;
+                return $cached;
+            }
+        }
+
+        $json = self::loadJsonFromDatabase($id);
+        if ( ! is_string($json) || strlen($json) < 1 ) {
+            return false;
+        }
+        self::$requestJson[$id] = $json;
+        if ( $cache && method_exists($cache, 'isEnabled') && $cache->isEnabled()
+                && method_exists($cache, 'set') ) {
+            $cache->set(self::cacheKey($id), $json, self::CACHE_TTL);
+        }
+        return $json;
+    }
+
+    /**
+     * True if this request has a course document (active manifest or readable $CFG->lessons).
+     */
+    public static function hasCurrent() {
+        if ( self::activeId() > 0 ) {
+            return true;
+        }
+        global $CFG;
+        return isset($CFG->lessons) && is_string($CFG->lessons) && strlen($CFG->lessons) > 0
+            && is_readable($CFG->lessons);
+    }
+
+    /**
+     * Like {@see currentLessons()} but dies if neither a manifest nor a file is available.
+     *
+     * @return Lessons
+     */
+    public static function requireCurrentLessons($anchor = null) {
+        $l = self::currentLessons($anchor);
+        if ( ! $l ) {
+            die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
+        }
+        return $l;
+    }
+
+    /**
+     * Lessons for the current context: manifest JSON if active, else $CFG->lessons file.
+     *
+     * @return Lessons|false
+     */
+    public static function currentLessons($anchor = null) {
+        $id = self::activeId();
+        if ( $id > 0 ) {
+            $json = self::loadJson($id);
+            if ( is_string($json) ) {
+                return Lessons::fromJson($json, $anchor);
+            }
+            return false;
+        }
+        global $CFG;
+        if ( isset($CFG->lessons) && is_string($CFG->lessons) && strlen($CFG->lessons) > 0
+                && is_readable($CFG->lessons) ) {
+            return new Lessons($CFG->lessons, $anchor);
+        }
+        return false;
+    }
+
+    /**
+     * Raw JSON for authoring: manifest row or $CFG->lessons file.
+     *
+     * @return array{json: string, label: string, manifest_id: int, version: int}|false
+     */
+    public static function currentDocument() {
+        $id = self::activeId();
+        if ( $id > 0 ) {
+            $json = self::loadJson($id);
+            if ( ! is_string($json) ) {
+                return false;
+            }
+            $row = self::loadRow($id);
+            $ver = is_array($row) && isset($row['version']) ? (int) $row['version'] : 0;
+            $label = 'manifest #' . $id;
+            if ( $ver > 0 ) {
+                $label .= ' (v' . $ver . ')';
+            }
+            return array('json' => $json, 'label' => $label, 'manifest_id' => $id, 'version' => $ver);
+        }
+        global $CFG;
+        if ( isset($CFG->lessons) && is_string($CFG->lessons) && is_readable($CFG->lessons) ) {
+            $json = file_get_contents($CFG->lessons);
+            if ( $json === false ) {
+                return false;
+            }
+            return array('json' => $json, 'label' => $CFG->lessons, 'manifest_id' => 0, 'version' => 0);
+        }
+        return false;
+    }
+
+    /**
+     * Insert an immutable new version and point lti_context.manifest_id at it.
+     *
+     * @param array<string, mixed>|object|string $data Decoded document or JSON string
+     * @return int New manifest_id
+     */
+    public static function saveNewVersion($context_id, $data, $user_id = null, $comment = null) {
+        global $CFG;
+        $cid = (int) $context_id;
+        if ( $cid < 1 ) {
+            throw new \InvalidArgumentException('saveNewVersion requires a context_id');
+        }
+        if ( is_string($data) ) {
+            $decoded = json_decode($data, true);
+            if ( ! is_array($decoded) ) {
+                throw new \InvalidArgumentException('saveNewVersion: invalid JSON');
+            }
+            $data = $decoded;
+        } elseif ( is_object($data) ) {
+            $data = json_decode(json_encode($data), true);
+            if ( ! is_array($data) ) {
+                throw new \InvalidArgumentException('saveNewVersion: invalid document');
+            }
+        }
+        if ( ! is_array($data) ) {
+            throw new \InvalidArgumentException('saveNewVersion: expected array or JSON');
+        }
+
+        $json = self::encode($data);
+        if ( ! is_string($json) ) {
+            throw new \InvalidArgumentException('saveNewVersion: JSON encode failed');
+        }
+        $loadError = self::validateJson($json);
+        if ( $loadError !== null ) {
+            throw new \InvalidArgumentException($loadError);
+        }
+        $title = isset($data['title']) && is_string($data['title']) ? $data['title'] : null;
+        $uid = $user_id === null ? null : (int) $user_id;
+        if ( $uid !== null && $uid < 1 ) {
+            $uid = null;
+        }
+        $comment = is_string($comment) && strlen(trim($comment)) > 0 ? trim($comment) : null;
+
+        $PDOX = LTIX::getConnection();
+        $p = $CFG->dbprefix;
+        $next = $PDOX->rowDie(
+            "SELECT COALESCE(MAX(version), 0) + 1 AS next_version
+             FROM {$p}manifest WHERE context_id = :CID",
+            array(':CID' => $cid)
+        );
+        $version = is_array($next) ? (int) $next['next_version'] : 1;
+        if ( $version < 1 ) {
+            $version = 1;
+        }
+
+        $PDOX->queryDie(
+            "INSERT INTO {$p}manifest
+                (context_id, version, title, manifest, comment, user_id, created_at)
+             VALUES
+                (:context_id, :version, :title, :manifest, :comment, :user_id, NOW())",
+            array(
+                ':context_id' => $cid,
+                ':version' => $version,
+                ':title' => $title,
+                ':manifest' => $json,
+                ':comment' => $comment,
+                ':user_id' => $uid,
+            )
+        );
+        $manifest_id = (int) $PDOX->lastInsertId();
+        self::setActive($cid, $manifest_id);
+        self::$requestJson[$manifest_id] = $json;
+        $cache = self::mcache();
+        if ( $cache && method_exists($cache, 'isEnabled') && $cache->isEnabled()
+                && method_exists($cache, 'set') ) {
+            $cache->set(self::cacheKey($manifest_id), $json, self::CACHE_TTL);
+        }
+        return $manifest_id;
+    }
+
+    /**
+     * Point a context at an existing manifest row (must belong to that context).
+     */
+    public static function setActive($context_id, $manifest_id) {
+        global $CFG;
+        $cid = (int) $context_id;
+        $mid = (int) $manifest_id;
+        if ( $cid < 1 || $mid < 1 ) {
+            throw new \InvalidArgumentException('setActive requires context_id and manifest_id');
+        }
+        $PDOX = LTIX::getConnection();
+        $p = $CFG->dbprefix;
+        $row = $PDOX->rowDie(
+            "SELECT manifest_id FROM {$p}manifest
+             WHERE manifest_id = :MID AND context_id = :CID",
+            array(':MID' => $mid, ':CID' => $cid)
+        );
+        if ( ! $row ) {
+            throw new \InvalidArgumentException('manifest does not belong to this context');
+        }
+        $PDOX->queryDie(
+            "UPDATE {$p}lti_context SET manifest_id = :MID, updated_at = NOW()
+             WHERE context_id = :CID",
+            array(':MID' => $mid, ':CID' => $cid)
+        );
+        if ( U::currentContextId() === $cid ) {
+            self::rememberInSession($mid);
+        }
+    }
+
+    /**
+     * Create an LTI context, instructor membership, and starter manifest version 1.
+     *
+     * @return array{ok: bool, context_id?: int, manifest_id?: int, error?: string}
+     */
+    public static function createCourse($title, $user_id, $key_id) {
+        global $CFG;
+        $title = is_string($title) ? trim($title) : '';
+        if ( $title === '' ) {
+            return array('ok' => false, 'error' => 'Title is required.');
+        }
+        $user_id = (int) $user_id;
+        $key_id = (int) $key_id;
+        if ( $user_id < 1 ) {
+            return array('ok' => false, 'error' => 'Must be logged in.');
+        }
+        if ( $key_id < 1 ) {
+            return array('ok' => false, 'error' => 'Missing consumer key.');
+        }
+
+        $PDOX = LTIX::getConnection();
+        $p = $CFG->dbprefix;
+        $context_key = 'course:' . bin2hex(random_bytes(16));
+
+        $PDOX->queryDie(
+            "INSERT INTO {$p}lti_context
+                (context_key, context_sha256, title, key_id, user_id, created_at, updated_at)
+             VALUES
+                (:context_key, :context_sha256, :title, :key_id, :user_id, NOW(), NOW())",
+            array(
+                ':context_key' => $context_key,
+                ':context_sha256' => lti_sha256($context_key),
+                ':title' => $title,
+                ':key_id' => $key_id,
+                ':user_id' => $user_id,
+            )
+        );
+        $context_id = (int) $PDOX->lastInsertId();
+        if ( $context_id < 1 ) {
+            return array('ok' => false, 'error' => 'Could not create course.');
+        }
+
+        $PDOX->queryDie(
+            "INSERT INTO {$p}lti_membership
+                (context_id, user_id, role, created_at, updated_at)
+             VALUES
+                (:context_id, :user_id, :role, NOW(), NOW())",
+            array(
+                ':context_id' => $context_id,
+                ':user_id' => $user_id,
+                ':role' => LTIX::ROLE_INSTRUCTOR,
+            )
+        );
+
+        $manifest_id = self::saveNewVersion(
+            $context_id,
+            self::starter($title),
+            $user_id,
+            'Created course'
+        );
+        return array(
+            'ok' => true,
+            'context_id' => $context_id,
+            'manifest_id' => $manifest_id,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|false
+     */
+    public static function loadRow($manifest_id) {
+        global $CFG;
+        $id = (int) $manifest_id;
+        if ( $id < 1 ) {
+            return false;
+        }
+        $PDOX = LTIX::getConnection();
+        $p = $CFG->dbprefix;
+        $row = $PDOX->rowDie(
+            "SELECT manifest_id, context_id, version, title, manifest, comment, user_id, created_at
+             FROM {$p}manifest WHERE manifest_id = :MID",
+            array(':MID' => $id)
+        );
+        return is_array($row) ? $row : false;
+    }
+
+    /**
+     * @return string|false
+     */
+    private static function loadJsonFromDatabase($manifest_id) {
+        $row = self::loadRow($manifest_id);
+        if ( ! is_array($row) ) {
+            return false;
+        }
+        $json = $row['manifest'] ?? '';
+        return is_string($json) && strlen($json) > 0 ? $json : false;
+    }
+
+    /**
+     * @return int
+     */
+    private static function positiveId($value) {
+        if ( function_exists('_tsugiNormalizePositiveId') ) {
+            return _tsugiNormalizePositiveId($value);
+        }
+        if ( $value === null || $value === false || $value === '' || is_bool($value) ) {
+            return 0;
+        }
+        if ( ! is_numeric($value) ) {
+            return 0;
+        }
+        $intval = (int) $value;
+        return $intval > 0 ? $intval : 0;
+    }
+
+    /**
+     * @return MCache|object|null
+     */
+    private static function mcache() {
+        global $CFG;
+        if ( self::$mcache !== null ) {
+            return self::$mcache;
+        }
+        if ( ! is_object($CFG) ) {
+            return null;
+        }
+        self::$mcache = new MCache($CFG);
+        return self::$mcache;
+    }
+}

--- a/lib/src/Core/Manifest.php
+++ b/lib/src/Core/Manifest.php
@@ -40,6 +40,9 @@ class Manifest {
     /** @var array<int, string> Request-local JSON strings keyed by manifest_id. */
     private static $requestJson = array();
 
+    /** @var array<int, array<string, mixed>> Request-local manifest rows keyed by manifest_id. */
+    private static $requestRows = array();
+
     /** @var MCache|object|null Injected or lazy MCache; false means "constructed empty". */
     private static $mcache = null;
 
@@ -48,6 +51,7 @@ class Manifest {
      */
     public static function resetRequestCache() {
         self::$requestJson = array();
+        self::$requestRows = array();
     }
 
     /**
@@ -101,6 +105,171 @@ class Manifest {
                 ),
             ),
         );
+    }
+
+    /**
+     * Named course palettes (legacy $CFG->theme shape).
+     *
+     * Keys are stored in manifest.theme. NULL / empty means the site $CFG->theme.
+     * Samples taken from peer tsugi_settings.php files (DJ4E, PG4E/CC4E, WS2),
+     * PY4E-AI ($CFG->theme_base / --ai-accent), plus the Tsugi default primary
+     * from Theme::defaults().
+     *
+     * @return array<string, array<string, string>>
+     */
+    public static function palettes() {
+        return array(
+            'tsugi' => array(
+                'label' => 'Tsugi Blue',
+                'primary' => '#0D47A1',
+                'secondary' => '#EEEEEE',
+                'text' => '#111111',
+                'text-light' => '#5E5E5E',
+                'font-family' => 'sans-serif',
+                'font-size' => '14px',
+            ),
+            'django' => array(
+                'label' => 'Django Green',
+                'primary' => '#0a4b33',
+                'secondary' => '#EEEEEE',
+                'text' => '#111111',
+                'text-light' => '#5E5E5E',
+                'font-url' => 'https://fonts.googleapis.com/css?family=Roboto:400',
+                'font-family' => "'Roboto', Corbel, Avenir, 'Lucida Grande', 'Lucida Sans', sans-serif",
+                'font-size' => '14px',
+            ),
+            'postgres' => array(
+                'label' => 'Postgres Blue',
+                'primary' => '#336791',
+                'secondary' => '#EEEEEE',
+                'text' => '#111111',
+                'text-light' => '#5E5E5E',
+                'font-url' => 'https://fonts.googleapis.com/css2?family=Open+Sans',
+                'font-family' => "'Open Sans', Corbel, Avenir, 'Lucida Grande', 'Lucida Sans', sans-serif",
+                'font-size' => '14px',
+            ),
+            'navy' => array(
+                'label' => 'Navy',
+                'primary' => '#000060',
+                'secondary' => '#EEEEEE',
+                'text' => '#111111',
+                'text-light' => '#5E5E5E',
+                'font-url' => 'https://fonts.googleapis.com/css?family=Roboto:400',
+                'font-family' => "'Roboto', Corbel, Avenir, 'Lucida Grande', 'Lucida Sans', sans-serif",
+                'font-size' => '14px',
+            ),
+            'electric' => array(
+                'label' => 'Electric',
+                'primary' => '#7c3aed',
+                'secondary' => '#EEEEEE',
+                'text' => '#1e1b4b',
+                'text-light' => '#4338ca',
+                'font-family' => 'sans-serif',
+                'font-size' => '14px',
+            ),
+        );
+    }
+
+    /**
+     * Palette array for a theme key, without the display label. Null if unknown or site default.
+     *
+     * @return array<string, string>|null
+     */
+    public static function palette($key) {
+        $norm = self::normalizeThemeKey($key);
+        if ( ! is_string($norm) ) {
+            return null;
+        }
+        $all = self::palettes();
+        if ( ! isset($all[$norm]) || ! is_array($all[$norm]) ) {
+            return null;
+        }
+        $p = $all[$norm];
+        unset($p['label']);
+        return $p;
+    }
+
+    /**
+     * Validate a posted theme key.
+     *
+     * @return string|null|false Named key, null for site default, false if unknown.
+     */
+    public static function normalizeThemeKey($key) {
+        if ( $key === null ) {
+            return null;
+        }
+        if ( ! is_string($key) ) {
+            return false;
+        }
+        $key = strtolower(trim($key));
+        if ( $key === '' || $key === 'default' || $key === 'site' ) {
+            return null;
+        }
+        $all = self::palettes();
+        if ( ! isset($all[$key]) ) {
+            return false;
+        }
+        return $key;
+    }
+
+    /**
+     * Theme key stored on the active manifest row (empty string = site default).
+     */
+    public static function currentThemeKey() {
+        $id = self::activeId();
+        if ( $id < 1 ) {
+            return '';
+        }
+        $row = self::loadRow($id);
+        if ( ! is_array($row) ) {
+            return '';
+        }
+        $key = $row['theme'] ?? '';
+        return is_string($key) ? $key : '';
+    }
+
+    /**
+     * Raw palette for the active named theme, or null to keep $CFG->theme.
+     *
+     * @return array<string, string>|null
+     */
+    public static function currentThemeArray() {
+        $key = self::currentThemeKey();
+        if ( $key === '' ) {
+            return null;
+        }
+        return self::palette($key);
+    }
+
+    /**
+     * Theme key currently pointed at by a context, or null.
+     *
+     * @return string|null
+     */
+    public static function themeKeyForContext($context_id) {
+        global $CFG;
+        $cid = (int) $context_id;
+        if ( $cid < 1 ) {
+            return null;
+        }
+        $PDOX = LTIX::getConnection();
+        $p = $CFG->dbprefix;
+        $row = $PDOX->rowDie(
+            "SELECT m.theme AS theme
+             FROM {$p}lti_context c
+             LEFT JOIN {$p}manifest m ON m.manifest_id = c.manifest_id
+             WHERE c.context_id = :CID",
+            array(':CID' => $cid)
+        );
+        if ( ! is_array($row) ) {
+            return null;
+        }
+        $key = $row['theme'] ?? null;
+        if ( ! is_string($key) || $key === '' ) {
+            return null;
+        }
+        $norm = self::normalizeThemeKey($key);
+        return is_string($norm) ? $norm : null;
     }
 
     /**
@@ -487,9 +656,11 @@ class Manifest {
      * Insert an immutable new version and point lti_context.manifest_id at it.
      *
      * @param array<string, mixed>|object|string $data Decoded document or JSON string
+     * @param string|null $theme Theme key. Null copies the previous version for this
+     *        context. Empty string stores NULL (site $CFG->theme).
      * @return int New manifest_id
      */
-    public static function saveNewVersion($context_id, $data, $user_id = null, $comment = null) {
+    public static function saveNewVersion($context_id, $data, $user_id = null, $comment = null, $theme = null) {
         global $CFG;
         $cid = (int) $context_id;
         if ( $cid < 1 ) {
@@ -528,6 +699,17 @@ class Manifest {
 
         $PDOX = LTIX::getConnection();
         $p = $CFG->dbprefix;
+
+        if ( $theme === null ) {
+            $themeToStore = self::themeKeyForContext($cid);
+        } else {
+            $norm = self::normalizeThemeKey($theme);
+            if ( $norm === false ) {
+                throw new \InvalidArgumentException('Unknown theme');
+            }
+            $themeToStore = $norm;
+        }
+
         $next = $PDOX->rowDie(
             "SELECT COALESCE(MAX(version), 0) + 1 AS next_version
              FROM {$p}manifest WHERE context_id = :CID",
@@ -540,13 +722,14 @@ class Manifest {
 
         $PDOX->queryDie(
             "INSERT INTO {$p}manifest
-                (context_id, version, title, manifest, comment, user_id, created_at)
+                (context_id, version, title, theme, manifest, comment, user_id, created_at)
              VALUES
-                (:context_id, :version, :title, :manifest, :comment, :user_id, NOW())",
+                (:context_id, :version, :title, :theme, :manifest, :comment, :user_id, NOW())",
             array(
                 ':context_id' => $cid,
                 ':version' => $version,
                 ':title' => $title,
+                ':theme' => $themeToStore,
                 ':manifest' => $json,
                 ':comment' => $comment,
                 ':user_id' => $uid,
@@ -669,14 +852,21 @@ class Manifest {
         if ( $id < 1 ) {
             return false;
         }
+        if ( isset(self::$requestRows[$id]) ) {
+            return self::$requestRows[$id];
+        }
         $PDOX = LTIX::getConnection();
         $p = $CFG->dbprefix;
         $row = $PDOX->rowDie(
-            "SELECT manifest_id, context_id, version, title, manifest, comment, user_id, created_at
+            "SELECT manifest_id, context_id, version, title, theme, manifest, comment, user_id, created_at
              FROM {$p}manifest WHERE manifest_id = :MID",
             array(':MID' => $id)
         );
-        return is_array($row) ? $row : false;
+        if ( ! is_array($row) ) {
+            return false;
+        }
+        self::$requestRows[$id] = $row;
+        return $row;
     }
 
     /**

--- a/lib/src/Core/Manifest.php
+++ b/lib/src/Core/Manifest.php
@@ -173,6 +173,15 @@ class Manifest {
                 'font-family' => 'sans-serif',
                 'font-size' => '14px',
             ),
+            'grey' => array(
+                'label' => 'Light Grey',
+                'primary' => '#D0D0D0',
+                'secondary' => '#111111',
+                'text' => '#111111',
+                'text-light' => '#5E5E5E',
+                'font-family' => 'sans-serif',
+                'font-size' => '14px',
+            ),
         );
     }
 
@@ -216,6 +225,26 @@ class Manifest {
             return false;
         }
         return $key;
+    }
+
+    /**
+     * Nav primary color for the site default (no named course theme).
+     *
+     * Matches Output::get_theme() when manifest.theme is NULL: theme_base,
+     * then $CFG->theme primary, then the Tsugi default.
+     */
+    public static function siteDefaultPrimary() {
+        global $CFG;
+        if ( is_object($CFG) && isset($CFG->theme_base) && is_string($CFG->theme_base)
+                && U::isValidCSSColor($CFG->theme_base) ) {
+            return $CFG->theme_base;
+        }
+        if ( is_object($CFG) && isset($CFG->theme) && is_array($CFG->theme)
+                && isset($CFG->theme['primary']) && is_string($CFG->theme['primary'])
+                && U::isValidCSSColor($CFG->theme['primary']) ) {
+            return $CFG->theme['primary'];
+        }
+        return '#0D47A1';
     }
 
     /**

--- a/lib/src/Core/User.php
+++ b/lib/src/Core/User.php
@@ -210,4 +210,57 @@ class User {
         Cache::set($cacheloc, $row['user_id'], $row);
         return $row;
     }
+
+    /**
+     * Session key for {@see rememberCreateCourses()} (user-level, not a context role).
+     */
+    public const SESSION_CREATE_COURSES = 'create_courses';
+
+    /**
+     * Load lti_user.create_courses into the session. Call at login, never on course switch.
+     *
+     * @return bool True when the flag is set
+     */
+    public static function rememberCreateCourses($user_id) {
+        global $CFG, $PDOX;
+
+        $uid = (int) $user_id;
+        unset($_SESSION[self::SESSION_CREATE_COURSES]);
+        if ( $uid < 1 ) {
+            return false;
+        }
+        if ( $PDOX === null || $PDOX === false ) {
+            $PDOX = LTIX::getConnection();
+        }
+        $stmt = $PDOX->queryReturnError(
+            "SELECT create_courses FROM {$CFG->dbprefix}lti_user WHERE user_id = :UID",
+            array(':UID' => $uid)
+        );
+        if ( ! $stmt->success ) {
+            return false;
+        }
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $flag = ($row && (int) ($row['create_courses'] ?? 0) === 1) ? 1 : 0;
+        $_SESSION[self::SESSION_CREATE_COURSES] = $flag;
+        return $flag === 1;
+    }
+
+    /**
+     * True when the current user may mint a new site-login course.
+     *
+     * Site admins always pass. Everyone else needs lti_user.create_courses.
+     * Independent of instructor role in the current (or last) context.
+     */
+    public static function canCreateCourses() {
+        if ( ! U::isLoggedIn() ) {
+            return false;
+        }
+        if ( isset($_SESSION['admin']) && $_SESSION['admin'] == 'yes' ) {
+            return true;
+        }
+        if ( ! array_key_exists(self::SESSION_CREATE_COURSES, $_SESSION) ) {
+            self::rememberCreateCourses(U::loggedInUserId());
+        }
+        return (int) $_SESSION[self::SESSION_CREATE_COURSES] === 1;
+    }
 }

--- a/lib/src/UI/GoogleLoginHandler.php
+++ b/lib/src/UI/GoogleLoginHandler.php
@@ -7,6 +7,7 @@ use \Tsugi\Util\Net;
 use \Tsugi\Core\LTIX;
 use \Tsugi\Crypt\SecureCookie;
 use \Tsugi\Core\Cache;
+use \Tsugi\Core\User;
 use \Tsugi\Controllers\Login;
 
 /**
@@ -349,6 +350,7 @@ class GoogleLoginHandler {
         $_SESSION["id"] = $user_id;
         $lti["user_id"] = $user_id;
         $_SESSION["user_id"] = $user_id;
+        User::rememberCreateCourses($user_id);
         $_SESSION["user_key"] = $user_key;
         $lti["user_key"] = $user_key;
         $_SESSION["email"] = $userEmail;

--- a/lib/src/UI/GoogleLoginHandler.php
+++ b/lib/src/UI/GoogleLoginHandler.php
@@ -410,6 +410,7 @@ class GoogleLoginHandler {
         }
 
         $_SESSION[TSUGI_SESSION_LTI] = $lti;
+        LTIX::ensureCsrfToken(true);
         LTIX::noteLoggedIn($lti);
         if ( ! empty($CFG->enable_secure_cookie_login) ) {
             SecureCookie::set($user_id, $userEmail, $context_id);

--- a/lib/src/UI/Lessons.php
+++ b/lib/src/UI/Lessons.php
@@ -213,43 +213,110 @@ class Lessons {
         return $this->lessonsHome() . '_launch/' . $resource_link_id;
     }
 
+    /**
+     * When true, structural errors throw InvalidArgumentException instead of dying.
+     * Used by {@see tryFromJson()} so authoring can refuse a bad save.
+     */
+    private static $throwOnError = false;
+
+    /**
+     * Load JSON without killing the request.
+     *
+     * @return Lessons|string Lessons on success, error message on failure
+     */
+    public static function tryFromJson($json_str, $anchor=null, $index=null)
+    {
+        $prev = self::$throwOnError;
+        self::$throwOnError = true;
+        try {
+            return self::fromJson($json_str, $anchor, $index);
+        } catch (\Throwable $e) {
+            return $e->getMessage();
+        } finally {
+            self::$throwOnError = $prev;
+        }
+    }
+
+    /**
+     * Build a Lessons object from a JSON string (file or manifest document).
+     */
+    public static function fromJson($json_str, $anchor=null, $index=null)
+    {
+        $lessons = json_decode($json_str);
+        if ( $lessons === null ) {
+            $msg = 'Problem parsing lessons.json: ' . json_last_error_msg();
+            if ( self::$throwOnError ) {
+                throw new \InvalidArgumentException($msg);
+            }
+            echo("<pre>\n");
+            echo($msg);
+            echo("\n");
+            echo($json_str);
+            die();
+        }
+        return new self($lessons, $anchor, $index);
+    }
+
+    /**
+     * Fail a document load: throw when validating, otherwise die.
+     */
+    private static function fail($msg) {
+        if ( self::$throwOnError ) {
+            throw new \InvalidArgumentException($msg);
+        }
+        die_with_error_log($msg);
+    }
+
     /*
-     ** Load up the JSON from the file
+     ** Load up the JSON from a file path, or from an already-decoded object.
      **/
     public function __construct($name='lessons.json', $anchor=null, $index=null)
     {
         global $CFG;
 
-        $json_str = file_get_contents($name);
-        $lessons = json_decode($json_str);
+        if ( is_object($name) ) {
+            $lessons = $name;
+        } else {
+            $json_str = file_get_contents($name);
+            $lessons = json_decode($json_str);
+            $this->resource_links = array();
+
+            if ( $lessons === null ) {
+                echo("<pre>\n");
+                echo("Problem parsing lessons.json: ");
+                echo(json_last_error_msg());
+                echo("\n");
+                echo($json_str);
+                die();
+            }
+        }
+
         $this->resource_links = array();
 
-        if ( $lessons === null ) {
-            echo("<pre>\n");
-            echo("Problem parsing lessons.json: ");
-            echo(json_last_error_msg());
-            echo("\n");
-            echo($json_str);
-            die();
+        if ( ! is_object($lessons) ) {
+            self::fail('lessons.json must be a JSON object');
+        }
+        if ( ! isset($lessons->modules) || ! is_array($lessons->modules) ) {
+            self::fail('lessons.json must have a modules array');
         }
 
         // Demand that every module have required elments
         foreach($lessons->modules as $module) {
             if ( !isset($module->title) ) {
-                die_with_error_log('All modules in a lesson must have a title');
+                self::fail('All modules in a lesson must have a title');
             }
             if ( !isset($module->anchor) ) {
-                die_with_error_log('All modules must have an anchor: '.$module->title);
+                self::fail('All modules must have an anchor: '.$module->title);
             }
         }
 
         // Demand that every module have required elments
         if ( isset($lessons->badges) ) foreach($lessons->badges as $badge) {
             if ( !isset($badge->title) ) {
-                die_with_error_log('All badges in a lesson must have a title');
+                self::fail('All badges in a lesson must have a title');
             }
             if ( !isset($badge->assignments) ) {
-                die_with_error_log('All badges must have assignments: '.$badge->title);
+                self::fail('All badges must have assignments: '.$badge->title);
             }
         }
 
@@ -280,11 +347,11 @@ class Lessons {
 
             // Non arrays
             if ( isset($this->lessons->modules[$i]->assignment) ) {
-                if ( ! is_string($this->lessons->modules[$i]->assignment) ) die_with_error_log('Assignment must be a string: '.$module->title);
+                if ( ! is_string($this->lessons->modules[$i]->assignment) ) self::fail('Assignment must be a string: '.$this->lessons->modules[$i]->title);
                 self::absolute_url_ref($this->lessons->modules[$i]->assignment);
             }
             if ( isset($this->lessons->modules[$i]->solution) ) {
-                if ( ! is_string($this->lessons->modules[$i]->solution) ) die_with_error_log('Solution must be a string: '.$module->title);
+                if ( ! is_string($this->lessons->modules[$i]->solution) ) self::fail('Solution must be a string: '.$this->lessons->modules[$i]->title);
                 self::absolute_url_ref($this->lessons->modules[$i]->solution);
             }
 
@@ -313,7 +380,7 @@ class Lessons {
                     if ( !isset($item->type) ) continue;
                     if ( ($item->type == 'lti' || $item->type == 'discussion') && isset($item->resource_link_id) ) {
                         if (isset($this->resource_links[$item->resource_link_id]) ) {
-                            die_with_error_log('Duplicate resource link in Lessons '. $item->resource_link_id);
+                            self::fail('Duplicate resource link in Lessons '. $item->resource_link_id);
                         }
                         $this->resource_links[$item->resource_link_id] = $module->anchor;
                     }
@@ -325,13 +392,13 @@ class Lessons {
                     if ( ! is_array($ltis) ) $ltis = array($ltis);
                     foreach($ltis as $lti) {
                         if ( ! isset($lti->title) ) {
-                            die_with_error_log('Missing lti title in module:'. $module->title);
+                            self::fail('Missing lti title in module:'. $module->title);
                         }
                         if ( ! isset($lti->resource_link_id) ) {
-                            die_with_error_log('Missing resource link in Lessons '. $lti->title);
+                            self::fail('Missing resource link in Lessons '. $lti->title);
                         }
                         if (isset($this->resource_links[$lti->resource_link_id]) ) {
-                            die_with_error_log('Duplicate resource link in Lessons '. $lti->resource_link_id);
+                            self::fail('Duplicate resource link in Lessons '. $lti->resource_link_id);
                         }
                         $this->resource_links[$lti->resource_link_id] = $module->anchor;
                     }
@@ -342,13 +409,13 @@ class Lessons {
                     if ( ! is_array($discussions) ) $discussions = array($discussions);
                     foreach($discussions as $discussion) {
                         if ( ! isset($discussion->title) ) {
-                            die_with_error_log('Missing discussion title in module:'. $module->title);
+                            self::fail('Missing discussion title in module:'. $module->title);
                         }
                         if ( ! isset($discussion->resource_link_id) ) {
-                            die_with_error_log('Missing resource link in Lessons '. $discussion->title);
+                            self::fail('Missing resource link in Lessons '. $discussion->title);
                         }
                         if (isset($this->resource_links[$discussion->resource_link_id]) ) {
-                            die_with_error_log('Duplicate resource link in Lessons '. $discussion->resource_link_id);
+                            self::fail('Duplicate resource link in Lessons '. $discussion->resource_link_id);
                         }
                         $this->resource_links[$discussion->resource_link_id] = $module->anchor;
                     }
@@ -361,16 +428,16 @@ class Lessons {
             self::adjustArray($this->lessons->launches);
             foreach ( $this->lessons->launches as $launch ) {
                 if ( ! isset($launch->title) ) {
-                    die_with_error_log('All launches in lessons must have a title');
+                    self::fail('All launches in lessons must have a title');
                 }
                 if ( ! isset($launch->resource_link_id) ) {
-                    die_with_error_log('All launches must have resource_link_id: '.$launch->title);
+                    self::fail('All launches must have resource_link_id: '.$launch->title);
                 }
                 if ( ! isset($launch->launch) ) {
-                    die_with_error_log('All launches must have launch URL: '.$launch->title);
+                    self::fail('All launches must have launch URL: '.$launch->title);
                 }
                 if ( isset($this->resource_links[$launch->resource_link_id]) ) {
-                    die_with_error_log('Duplicate resource link in Lessons '. $launch->resource_link_id);
+                    self::fail('Duplicate resource link in Lessons '. $launch->resource_link_id);
                 }
                 $this->resource_links[$launch->resource_link_id] = '';
             }
@@ -2282,12 +2349,12 @@ class Lessons {
         echo($ob_output);
     }
 
-    public function renderDiscussions($buffer=false, $toolHome=null)
-    {
-        ob_start();
-        global $CFG, $OUTPUT, $PDOX;
-
-        // Flatten the discussions
+    /**
+     * Catalog discussions: top-level, then module items, then optional discussion_order.
+     *
+     * @return array<int, object>
+     */
+    public function flattenedDiscussions() {
         $discussions = array();
         if (isset($this->lessons->discussions) ) {
             foreach($this->lessons->discussions as $discussion) {
@@ -2297,12 +2364,10 @@ class Lessons {
 
         foreach($this->lessons->modules as $module) {
             if ( isset($module->hidden) && $module->hidden ) continue;
-            
-            // Check if module uses items array (new format)
+
             $has_items = isset($module->items) && is_array($module->items) && count($module->items) > 0;
-            
+
             if ( $has_items ) {
-                // New format: scan items array for discussion items
                 foreach($module->items as $item) {
                     $item_obj = is_array($item) ? (object)$item : $item;
                     if ( isset($item_obj->type) && $item_obj->type == 'discussion' ) {
@@ -2310,7 +2375,6 @@ class Lessons {
                     }
                 }
             } else {
-                // Legacy format: scan discussions array
                 if ( isset($module->discussions) && is_array($module->discussions) ) {
                     foreach($module->discussions as $discussion) {
                         $discussions [] = $discussion;
@@ -2319,7 +2383,66 @@ class Lessons {
             }
         }
 
-        if ( count($discussions) < 1 || ! isset($CFG->tdiscus) || empty($CFG->tdiscus) ) {
+        if ( isset($this->lessons->discussion_order) && is_array($this->lessons->discussion_order) ) {
+            $discussions = self::applyDiscussionOrder($discussions, $this->lessons->discussion_order);
+        }
+        return $discussions;
+    }
+
+    /**
+     * Sort flattened discussion objects by a resource_link_id order list.
+     *
+     * @param array<int, object> $discussions
+     * @param array<int, mixed> $order
+     * @return array<int, object>
+     */
+    public static function applyDiscussionOrder($discussions, $order) {
+        if ( ! is_array($discussions) || ! is_array($order) ) {
+            return is_array($discussions) ? $discussions : array();
+        }
+        $by = array();
+        $rest = array();
+        foreach ( $discussions as $d ) {
+            $rid = '';
+            if ( is_object($d) && isset($d->resource_link_id) ) {
+                $rid = (string) $d->resource_link_id;
+            }
+            if ( $rid !== '' && ! isset($by[$rid]) ) {
+                $by[$rid] = $d;
+            } else {
+                $rest[] = $d;
+            }
+        }
+        $out = array();
+        foreach ( $order as $rid ) {
+            $rid = is_string($rid) || is_int($rid) ? (string) $rid : '';
+            if ( $rid !== '' && isset($by[$rid]) ) {
+                $out[] = $by[$rid];
+                unset($by[$rid]);
+            }
+        }
+        foreach ( $by as $d ) {
+            $out[] = $d;
+        }
+        foreach ( $rest as $d ) {
+            $out[] = $d;
+        }
+        return $out;
+    }
+
+    public function renderDiscussions($buffer=false, $toolHome=null, $addUrl=null, $reorderUrl=null)
+    {
+        ob_start();
+        global $CFG, $OUTPUT, $PDOX;
+
+        $discussions = $this->flattenedDiscussions();
+
+        $can_add = is_string($addUrl) && strlen($addUrl) > 0;
+        $can_reorder = is_string($reorderUrl) && strlen($reorderUrl) > 0 && count($discussions) > 1;
+        $tdiscus_ok = isset($CFG->tdiscus) && ! empty($CFG->tdiscus);
+        $show_catalog = $tdiscus_ok && count($discussions) > 0;
+
+        if ( ! $show_catalog && ! $can_add ) {
             echo('<h1>'.__('Discussions not available')."</h1>\n");
             $ob_output = ob_get_contents();
             ob_end_clean();
@@ -2331,11 +2454,23 @@ class Lessons {
         if ( $toolHome === null || $toolHome === '' ) {
             $toolHome = \Tsugi\Controllers\Tool::determineToolHome('/discussions');
         }
+
+        echo('<h1>'.__('Discussions:').' '.$this->lessons->title."</h1>\n");
+        if ( ! $show_catalog ) {
+            echo('<p>'.__('No discussions yet.')."</p>\n");
+            if ( $can_add ) {
+                echo('<p><a href="'.htmlspecialchars($addUrl).'" class="btn btn-primary btn-sm">'.htmlentities(__('Add discussion')).'</a></p>'."\n");
+            }
+            $ob_output = ob_get_contents();
+            ob_end_clean();
+            if ( $buffer ) return $ob_output;
+            echo($ob_output);
+            return;
+        }
+
         $json_endpoint = U::addSession($toolHome . '/json');
         $mark_read_url = U::addSession($toolHome . '/mark-read');
         $manage_discussions_url = U::addSession($toolHome . '/manage');
-
-        echo('<h1>'.__('Discussions:').' '.$this->lessons->title."</h1>\n");
 
         // TODO: Perhaps the tdiscus service will get promoted to Tsugi
         // but for now we bypass the abstraction and go straight to the source...
@@ -2410,6 +2545,12 @@ class Lessons {
             echo('</form>'."\n");
             if ( $show_expire_button ) {
                 echo('<a href="'.htmlspecialchars($manage_discussions_url).'" class="btn btn-warning btn-sm">'.htmlentities(__('Manage Discussions')).'</a>');
+            }
+            if ( $can_add ) {
+                echo('<a href="'.htmlspecialchars($addUrl).'" class="btn btn-primary btn-sm">'.htmlentities(__('Add discussion')).'</a>');
+            }
+            if ( $can_reorder ) {
+                echo('<a href="'.htmlspecialchars($reorderUrl).'" class="btn btn-default btn-sm">'.htmlentities(__('Reorder discussions')).'</a>');
             }
             echo("</div>\n");
         }

--- a/lib/src/UI/Output.php
+++ b/lib/src/UI/Output.php
@@ -6,6 +6,7 @@ namespace Tsugi\UI;
 use \Tsugi\Util\U;
 use Tsugi\Util\LTI;
 use Tsugi\Core\LTIX;
+use Tsugi\Core\Manifest;
 use Tsugi\Core\WebSocket;
 use Tsugi\UI\HandleBars;
 use Tsugi\UI\Theme;
@@ -1414,6 +1415,16 @@ $( function() {
         Theme::$dark_mode = $dark_mode;
         Theme::$theme_base = $theme_base;
 
+        $courseTheme = null;
+        if ( Manifest::activeId() > 0 ) {
+            $courseTheme = Manifest::currentThemeArray();
+        }
+        if ( is_array($courseTheme) ) {
+            $theme = self::themeDefaultsPreservingFont($courseTheme);
+            if (is_object($TSUGI_LAUNCH)) $_SESSION['tsugi_theme'] = $theme;
+            return $theme;
+        }
+
         // Generate the theme
         if (isset($theme_base) && U::isValidCSSColor($theme_base)) {
             $theme = Theme::getLegacyTheme($theme_base, $dark_mode);
@@ -1434,7 +1445,7 @@ $( function() {
             $theme = $CFG->theme;
         }
 
-        $theme = Theme::defaults($theme);
+        $theme = self::themeDefaultsPreservingFont($theme);
 
         // Check for individual overides from link, context, key, or launch
         foreach($theme as $name => $value ) {
@@ -1556,6 +1567,21 @@ body {
         }
         $style .= '}</style>'."\n";
         return $style;
+    }
+
+    /**
+     * Theme::defaults() rebuilds the array and drops extras such as font-url.
+     *
+     * @param array<string, mixed> $theme
+     * @return array<string, mixed>
+     */
+    public static function themeDefaultsPreservingFont($theme) {
+        $fontUrl = is_array($theme) ? ($theme['font-url'] ?? null) : null;
+        $theme = Theme::defaults(is_array($theme) ? $theme : array());
+        if ( is_string($fontUrl) && $fontUrl !== '' ) {
+            $theme['font-url'] = $fontUrl;
+        }
+        return $theme;
     }
 
 }

--- a/lib/tests/Controllers/CoursesControllerTest.php
+++ b/lib/tests/Controllers/CoursesControllerTest.php
@@ -251,4 +251,59 @@ class CoursesControllerTest extends \PHPUnit\Framework\TestCase
         _tsugiResetIdentitySnapshot();
         $this->assertSame(99, currentContextId());
     }
+
+    public function testCanCreateFalseWhenNotLoggedIn()
+    {
+        $this->assertFalse(Courses::canCreate());
+    }
+
+    public function testCanCreateTrueForSiteAdmin()
+    {
+        $_SESSION['id'] = 7;
+        $_SESSION['admin'] = 'yes';
+        $_SESSION['create_courses'] = 0;
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+        $this->assertTrue(Courses::canCreate());
+    }
+
+    public function testCanCreateUsesUserFlagNotInstructorSession()
+    {
+        $_SESSION['id'] = 7;
+        $_SESSION['instructor'] = true;
+        $_SESSION['isinstructor'] = true;
+        $_SESSION['create_courses'] = 0;
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+        $this->assertFalse(Courses::canCreate());
+
+        $_SESSION['create_courses'] = 1;
+        $this->assertTrue(Courses::canCreate());
+    }
+
+    public function testCreateGateRefusesWithoutFlag()
+    {
+        $_SESSION['id'] = 7;
+        $_SESSION['oauth_consumer_key'] = 'google.com';
+        $_SESSION['create_courses'] = 0;
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+        $response = Courses::createGateResponse('/courses');
+        $this->assertNotNull($response);
+        $this->assertSame(302, $response->getStatusCode());
+    }
+
+    public function testCreateGateAllowsFlag()
+    {
+        $_SESSION['id'] = 7;
+        $_SESSION['oauth_consumer_key'] = 'google.com';
+        $_SESSION['create_courses'] = 1;
+        if (function_exists('_tsugiResetIdentitySnapshot')) {
+            _tsugiResetIdentitySnapshot();
+        }
+        $this->assertNull(Courses::createGateResponse('/courses'));
+    }
 }

--- a/lib/tests/Controllers/CoursesControllerTest.php
+++ b/lib/tests/Controllers/CoursesControllerTest.php
@@ -78,6 +78,7 @@ class CoursesControllerTest extends \PHPUnit\Framework\TestCase
         $uris = $this->routeUris();
 
         $this->assertContains('/courses/json', $uris);
+        $this->assertContains('/courses/create', $uris);
         $this->assertContains('/courses', $uris);
         $this->assertContains('/courses/{id:\d+}', $uris);
         $this->assertContains('/courses/{id:\d+}/{rest:.*}', $uris);

--- a/lib/tests/Controllers/SetupControllerTest.php
+++ b/lib/tests/Controllers/SetupControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+require_once "src/Controllers/Setup.php";
+require_once "src/Controllers/Tool.php";
+require_once "src/Config/ConfigInfo.php";
+require_once "src/Lumen/Application.php";
+require_once "src/Lumen/Router.php";
+require_once "src/Util/U.php";
+
+use \Tsugi\Controllers\Setup;
+use \Tsugi\Lumen\Application;
+
+class SetupControllerTest extends \PHPUnit\Framework\TestCase
+{
+    private $originalCFG;
+    private $originalSession;
+    private $mockApp;
+
+    protected function setUp(): void
+    {
+        global $CFG;
+        $this->originalCFG = $CFG;
+        $this->originalSession = isset($_SESSION) && is_array($_SESSION) ? $_SESSION : array();
+        $_SESSION = array();
+
+        $CFG = new \Tsugi\Config\ConfigInfo(basename(__FILE__), 'http://localhost');
+        $CFG->wwwroot = 'http://localhost';
+        $CFG->apphome = 'http://localhost/app';
+        $CFG->dirroot = dirname(__DIR__, 3);
+
+        if (!isset($CFG->loader)) {
+            $autoloaderPath = __DIR__ . '/../../vendor/autoload.php';
+            if (file_exists($autoloaderPath)) {
+                $CFG->loader = require_once $autoloaderPath;
+            } else {
+                $CFG->loader = new \stdClass();
+            }
+        }
+
+        $mockLaunch = new \stdClass();
+        $mockLaunch->output = new \stdClass();
+        $mockLaunch->output->buffer = true;
+        $this->mockApp = new Application($mockLaunch);
+    }
+
+    protected function tearDown(): void
+    {
+        global $CFG;
+        $CFG = $this->originalCFG;
+        $_SESSION = $this->originalSession;
+    }
+
+    public function testRouteConstant()
+    {
+        $this->assertSame('/setup', Setup::ROUTE);
+        $this->assertSame('Setup', Setup::NAME);
+    }
+
+    public function testRoutesRegistersGetAndPost()
+    {
+        Setup::routes($this->mockApp);
+        $uris = array();
+        foreach ($this->mockApp->router->getRoutes() as $route) {
+            $uris[] = $route['uri'];
+        }
+        $this->assertContains('/setup', $uris);
+    }
+}

--- a/lib/tests/Controllers/SetupControllerTest.php
+++ b/lib/tests/Controllers/SetupControllerTest.php
@@ -65,4 +65,13 @@ class SetupControllerTest extends \PHPUnit\Framework\TestCase
         }
         $this->assertContains('/setup', $uris);
     }
+
+    public function testShowInMenuFalseWithoutManifest()
+    {
+        $this->assertFalse(Setup::showInMenu());
+        $_SESSION['id'] = 1;
+        $_SESSION['context_id'] = 1;
+        $_SESSION['instructor'] = true;
+        $this->assertFalse(Setup::showInMenu());
+    }
 }

--- a/lib/tests/Controllers/TsugiTest.php
+++ b/lib/tests/Controllers/TsugiTest.php
@@ -193,5 +193,14 @@ class TsugiTest extends \PHPUnit\Framework\TestCase
             }
         }
         $this->assertTrue($hasLoginRoute, 'Login route should be registered');
+
+        $hasSetupRoute = false;
+        foreach ($uris as $uri) {
+            if ($uri === '/setup' || $uri === '/setup/' || strpos($uri, '/setup') === 0) {
+                $hasSetupRoute = true;
+                break;
+            }
+        }
+        $this->assertTrue($hasSetupRoute, 'Setup route should be registered');
     }
 }

--- a/lib/tests/Core/ManifestTest.php
+++ b/lib/tests/Core/ManifestTest.php
@@ -1,0 +1,341 @@
+<?php
+
+require_once "src/Core/Manifest.php";
+require_once "src/Config/ConfigInfo.php";
+require_once "src/UI/Lessons.php";
+require_once "src/Core/I18N.php";
+require_once "include/setup_i18n.php";
+
+use \Tsugi\Core\Manifest;
+
+if (!function_exists('die_with_error_log')) {
+    function die_with_error_log($msg, $extra=false, $prefix="DIE:") {
+        throw new \RuntimeException($prefix.' '.$msg);
+    }
+}
+
+if (!function_exists('isLoggedIn')) {
+    function isLoggedIn() {
+        return !empty($_SESSION['id']);
+    }
+}
+
+class ManifestTest extends \PHPUnit\Framework\TestCase
+{
+    private $originalCFG;
+    private $originalSession;
+
+    protected function setUp(): void
+    {
+        global $CFG;
+        $this->originalCFG = $CFG;
+        $this->originalSession = isset($_SESSION) && is_array($_SESSION) ? $_SESSION : array();
+        $_SESSION = array();
+
+        $CFG = new \Tsugi\Config\ConfigInfo(basename(__FILE__), 'http://localhost');
+        $CFG->apphome = 'http://localhost/app';
+        $CFG->wwwroot = 'http://localhost';
+        $CFG->fontawesome = 'http://localhost/fontawesome';
+
+        Manifest::resetRequestCache();
+        Manifest::setMCache(null);
+    }
+
+    protected function tearDown(): void
+    {
+        global $CFG;
+        $CFG = $this->originalCFG;
+        $_SESSION = $this->originalSession;
+        Manifest::resetRequestCache();
+        Manifest::setMCache(null);
+    }
+
+    public function testStarterHasRequiredShape()
+    {
+        $doc = Manifest::starter('My Course');
+        $this->assertSame('My Course', $doc['title']);
+        $this->assertTrue($doc['count']);
+        $this->assertSame(array(), $doc['badges']);
+        $this->assertSame(array(), $doc['discussions']);
+        $this->assertCount(1, $doc['modules']);
+        $this->assertSame('Week 1', $doc['modules'][0]['title']);
+        $this->assertSame('week-1', $doc['modules'][0]['anchor']);
+        $this->assertSame(array(), $doc['modules'][0]['items']);
+    }
+
+    public function testStarterBlankTitle()
+    {
+        $doc = Manifest::starter('  ');
+        $this->assertSame('Untitled Course', $doc['title']);
+    }
+
+    public function testStarterParsesAsLessons()
+    {
+        $json = Manifest::encode(Manifest::starter('Parse Me'));
+        $lessons = \Tsugi\UI\Lessons::fromJson($json);
+        $this->assertSame('Parse Me', $lessons->lessons->title);
+        $this->assertCount(1, $lessons->lessons->modules);
+        $this->assertSame('week-1', $lessons->lessons->modules[0]->anchor);
+    }
+
+    public function testCacheKeyUsesServerPrefixAndId()
+    {
+        global $CFG;
+        $CFG->wwwroot = 'http://example.com/tsugi';
+        $CFG->apphome = 'http://example.com';
+        $key = Manifest::cacheKey(42);
+        $this->assertStringEndsWith(':manifest:42', $key);
+        $this->assertStringContainsString('example.com', $key);
+        $this->assertStringNotContainsString('context', $key);
+    }
+
+    public function testActiveIdFromSessionBlob()
+    {
+        $_SESSION['lti'] = array('manifest_id' => '17');
+        $this->assertSame(17, Manifest::activeId());
+    }
+
+    public function testActiveIdZeroWhenMissing()
+    {
+        $this->assertSame(0, Manifest::activeId());
+    }
+
+    public function testRememberInSession()
+    {
+        Manifest::rememberInSession(9);
+        $this->assertSame(9, $_SESSION['manifest_id']);
+        $this->assertSame(9, $_SESSION['lti']['manifest_id']);
+        $this->assertSame(9, Manifest::activeId());
+        Manifest::rememberInSession(0);
+        $this->assertArrayNotHasKey('manifest_id', $_SESSION);
+        $this->assertSame(0, Manifest::activeId());
+    }
+
+    public function testLoadJsonUsesMCacheWithoutDatabase()
+    {
+        $json = Manifest::encode(Manifest::starter('Cached'));
+        $key = Manifest::cacheKey(99);
+        $fake = new ManifestTestMCache();
+        $fake->enabled = true;
+        $fake->store[$key] = $json;
+        Manifest::setMCache($fake);
+
+        $loaded = Manifest::loadJson(99);
+        $this->assertSame($json, $loaded);
+
+        Manifest::resetRequestCache();
+        $again = Manifest::loadJson(99);
+        $this->assertSame($json, $again);
+        $this->assertSame(2, $fake->gets);
+    }
+
+    public function testLoadJsonRequestMemoSkipsSecondCacheGet()
+    {
+        $json = Manifest::encode(Manifest::starter('Memo'));
+        $key = Manifest::cacheKey(5);
+        $fake = new ManifestTestMCache();
+        $fake->enabled = true;
+        $fake->store[$key] = $json;
+        Manifest::setMCache($fake);
+
+        Manifest::loadJson(5);
+        Manifest::loadJson(5);
+        $this->assertSame(1, $fake->gets);
+    }
+
+    public function testLoadJsonDisabledCacheReturnsFalseWithoutDb()
+    {
+        $fake = new ManifestTestMCache();
+        $fake->enabled = false;
+        Manifest::setMCache($fake);
+        // No database in this unit test: miss + no PDOX should not throw from MCache.
+        // loadJsonFromDatabase will fail without a connection; skip if we cannot isolate.
+        $this->assertFalse($fake->isEnabled());
+    }
+
+    public function testCurrentLessonsPrefersManifestOverFile()
+    {
+        global $CFG;
+        $CFG->lessons = __DIR__ . '/../fixtures/lessons/py4e-modern-lessons-items.json';
+        $json = Manifest::encode(Manifest::starter('Sandbox Course'));
+        $fake = new ManifestTestMCache();
+        $fake->enabled = true;
+        $fake->store[Manifest::cacheKey(99)] = $json;
+        Manifest::setMCache($fake);
+        Manifest::rememberInSession(99);
+
+        $l = Manifest::currentLessons();
+        $this->assertInstanceOf(\Tsugi\UI\Lessons::class, $l);
+        $this->assertSame('Sandbox Course', $l->lessons->title);
+        $this->assertNotSame('Python for Everybody (PY4E)', $l->lessons->title);
+    }
+
+    public function testCurrentLessonsFallsBackToFile()
+    {
+        global $CFG;
+        $CFG->lessons = __DIR__ . '/../fixtures/lessons/py4e-modern-lessons-items.json';
+        $this->assertSame(0, Manifest::activeId());
+        $l = Manifest::currentLessons();
+        $this->assertInstanceOf(\Tsugi\UI\Lessons::class, $l);
+        $this->assertSame('Python for Everybody (PY4E)', $l->lessons->title);
+    }
+
+    public function testValidateJsonAcceptsStarter()
+    {
+        $json = Manifest::encode(Manifest::starter('Valid Course'));
+        $this->assertNull(Manifest::validateJson($json));
+    }
+
+    public function testValidateJsonRejectsEmpty()
+    {
+        $this->assertNotNull(Manifest::validateJson(''));
+        $this->assertNotNull(Manifest::validateJson('{'));
+        $this->assertNotNull(Manifest::validateJson('[]'));
+        $this->assertNotNull(Manifest::validateJson('{"title":"No modules"}'));
+    }
+
+    public function testValidateJsonRejectsMissingModuleTitle()
+    {
+        $doc = Manifest::starter('Broken');
+        unset($doc['modules'][0]['title']);
+        $err = Manifest::validateJson(Manifest::encode($doc));
+        $this->assertIsString($err);
+        $this->assertStringContainsString('title', $err);
+    }
+
+    public function testValidateJsonRejectsDuplicateResourceLink()
+    {
+        $doc = Manifest::starter('Dup');
+        $doc['modules'][0]['items'] = array(
+            array(
+                'type' => 'lti',
+                'title' => 'One',
+                'resource_link_id' => 'same-id',
+                'launch' => 'http://example.com/one',
+            ),
+            array(
+                'type' => 'lti',
+                'title' => 'Two',
+                'resource_link_id' => 'same-id',
+                'launch' => 'http://example.com/two',
+            ),
+        );
+        $err = Manifest::validateJson(Manifest::encode($doc));
+        $this->assertIsString($err);
+        $this->assertStringContainsString('Duplicate', $err);
+    }
+
+    public function testExportFilename()
+    {
+        $this->assertSame(
+            'Python-for-Everybody-V2-2026-08-28-lessons.json',
+            Manifest::exportFilename('Python for Everybody', 2, '2026-08-28')
+        );
+        $this->assertSame(
+            'lessons-2026-08-28.json',
+            Manifest::exportFilename('', 0, '2026-08-28')
+        );
+        $this->assertSame(
+            'lessons-V3-2026-08-28.json',
+            Manifest::exportFilename('***', 3, '2026-08-28')
+        );
+        $today = date('Y-m-d');
+        $this->assertSame(
+            'Sandbox-V1-'.$today.'-lessons.json',
+            Manifest::exportFilename('Sandbox', 1)
+        );
+    }
+
+    public function testAppendDiscussionAddsTopLevelEntry()
+    {
+        $doc = Manifest::starter('Sandbox');
+        $result = Manifest::appendDiscussion($doc, 'Office Hours');
+        $this->assertSame('discussion_office_hours', $result['resource_link_id']);
+        $this->assertCount(1, $result['data']['discussions']);
+        $this->assertSame('Office Hours', $result['data']['discussions'][0]['title']);
+        $this->assertSame('mod/tdiscus/', $result['data']['discussions'][0]['launch']);
+        $this->assertSame('discussion_office_hours', $result['data']['discussions'][0]['resource_link_id']);
+        $this->assertNull(Manifest::validateJson(Manifest::encode($result['data'])));
+    }
+
+    public function testAppendDiscussionRequiresTitle()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Manifest::appendDiscussion(Manifest::starter('Sandbox'), '  ');
+    }
+
+    public function testAppendDiscussionAvoidsDuplicateResourceLinkIds()
+    {
+        $doc = Manifest::starter('Sandbox');
+        $first = Manifest::appendDiscussion($doc, 'Hello');
+        $second = Manifest::appendDiscussion($first['data'], 'Hello');
+        $this->assertSame('discussion_hello', $first['resource_link_id']);
+        $this->assertSame('discussion_hello_2', $second['resource_link_id']);
+        $this->assertCount(2, $second['data']['discussions']);
+    }
+
+    public function testAppendDiscussionSkipsModuleItemRlids()
+    {
+        $doc = Manifest::starter('Sandbox');
+        $doc['modules'][0]['items'][] = array(
+            'type' => 'discussion',
+            'title' => 'Week talk',
+            'launch' => 'mod/tdiscus/',
+            'resource_link_id' => 'discussion_week_talk',
+        );
+        $result = Manifest::appendDiscussion($doc, 'Week talk');
+        $this->assertSame('discussion_week_talk_2', $result['resource_link_id']);
+    }
+
+    public function testReorderDiscussionsPermutesTopLevel()
+    {
+        $doc = Manifest::starter('Sandbox');
+        $doc = Manifest::appendDiscussion($doc, 'Alpha')['data'];
+        $doc = Manifest::appendDiscussion($doc, 'Beta')['data'];
+        $doc = Manifest::appendDiscussion($doc, 'Gamma')['data'];
+        $ids = array_column($doc['discussions'], 'resource_link_id');
+        $reversed = array_reverse($ids);
+        $reordered = Manifest::reorderDiscussions($doc, $reversed);
+        $this->assertSame($reversed, array_column($reordered['discussions'], 'resource_link_id'));
+        $this->assertSame($reversed, $reordered['discussion_order']);
+        $this->assertNull(Manifest::validateJson(Manifest::encode($reordered)));
+    }
+
+    public function testReorderDiscussionsRequiresOrder()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Manifest::reorderDiscussions(Manifest::starter('Sandbox'), array());
+    }
+
+    public function testAppendDiscussionExtendsDiscussionOrder()
+    {
+        $doc = Manifest::starter('Sandbox');
+        $doc = Manifest::appendDiscussion($doc, 'First')['data'];
+        $doc = Manifest::reorderDiscussions($doc, array($doc['discussions'][0]['resource_link_id']));
+        $after = Manifest::appendDiscussion($doc, 'Second');
+        $this->assertSame(
+            array($after['data']['discussions'][0]['resource_link_id'], $after['resource_link_id']),
+            $after['data']['discussion_order']
+        );
+    }
+}
+
+class ManifestTestMCache {
+    public $enabled = false;
+    public $store = array();
+    public $gets = 0;
+
+    public function isEnabled() {
+        return $this->enabled;
+    }
+
+    public function get($key) {
+        $this->gets++;
+        return isset($this->store[$key]) ? $this->store[$key] : false;
+    }
+
+    public function set($key, $value, $expiration = 0) {
+        $this->store[$key] = $value;
+        return true;
+    }
+}

--- a/lib/tests/Core/ManifestTest.php
+++ b/lib/tests/Core/ManifestTest.php
@@ -318,6 +318,42 @@ class ManifestTest extends \PHPUnit\Framework\TestCase
             $after['data']['discussion_order']
         );
     }
+
+    public function testPalettesIncludePeerSiteColors()
+    {
+        $palettes = Manifest::palettes();
+        $this->assertArrayHasKey('tsugi', $palettes);
+        $this->assertArrayHasKey('django', $palettes);
+        $this->assertArrayHasKey('postgres', $palettes);
+        $this->assertArrayHasKey('navy', $palettes);
+        $this->assertArrayHasKey('electric', $palettes);
+        $this->assertSame('#0D47A1', $palettes['tsugi']['primary']);
+        $this->assertSame('#0a4b33', $palettes['django']['primary']);
+        $this->assertSame('#336791', $palettes['postgres']['primary']);
+        $this->assertSame('#000060', $palettes['navy']['primary']);
+        $this->assertSame('#7c3aed', $palettes['electric']['primary']);
+        $this->assertSame('#0a4b33', Manifest::palette('django')['primary']);
+        $this->assertArrayNotHasKey('label', Manifest::palette('django'));
+    }
+
+    public function testNormalizeThemeKey()
+    {
+        $this->assertNull(Manifest::normalizeThemeKey(''));
+        $this->assertNull(Manifest::normalizeThemeKey('default'));
+        $this->assertNull(Manifest::normalizeThemeKey('site'));
+        $this->assertNull(Manifest::normalizeThemeKey(null));
+        $this->assertSame('django', Manifest::normalizeThemeKey('Django'));
+        $this->assertFalse(Manifest::normalizeThemeKey('not-a-theme'));
+        $this->assertFalse(Manifest::normalizeThemeKey(array('django')));
+        $this->assertNull(Manifest::palette(''));
+        $this->assertNull(Manifest::palette('bogus'));
+    }
+
+    public function testCurrentThemeKeyEmptyWithoutSession()
+    {
+        $this->assertSame('', Manifest::currentThemeKey());
+        $this->assertNull(Manifest::currentThemeArray());
+    }
 }
 
 class ManifestTestMCache {

--- a/lib/tests/Core/ManifestTest.php
+++ b/lib/tests/Core/ManifestTest.php
@@ -167,13 +167,11 @@ class ManifestTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($json, Manifest::loadJson(77));
     }
 
-    public function testLoadJsonDisabledCacheReturnsFalseWithoutDb()
+    public function testManifestTestMCacheIsDisabled()
     {
         $fake = new ManifestTestMCache();
         $fake->enabled = false;
         Manifest::setMCache($fake);
-        // No database in this unit test: miss + no PDOX should not throw from MCache.
-        // loadJsonFromDatabase will fail without a connection; skip if we cannot isolate.
         $this->assertFalse($fake->isEnabled());
     }
 

--- a/lib/tests/Core/ManifestTest.php
+++ b/lib/tests/Core/ManifestTest.php
@@ -351,11 +351,14 @@ class ManifestTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('postgres', $palettes);
         $this->assertArrayHasKey('navy', $palettes);
         $this->assertArrayHasKey('electric', $palettes);
+        $this->assertArrayHasKey('grey', $palettes);
         $this->assertSame('#0D47A1', $palettes['tsugi']['primary']);
         $this->assertSame('#0a4b33', $palettes['django']['primary']);
         $this->assertSame('#336791', $palettes['postgres']['primary']);
         $this->assertSame('#000060', $palettes['navy']['primary']);
         $this->assertSame('#7c3aed', $palettes['electric']['primary']);
+        $this->assertSame('#D0D0D0', $palettes['grey']['primary']);
+        $this->assertSame('#111111', $palettes['grey']['secondary']);
         $this->assertSame('#0a4b33', Manifest::palette('django')['primary']);
         $this->assertArrayNotHasKey('label', Manifest::palette('django'));
     }
@@ -371,6 +374,17 @@ class ManifestTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse(Manifest::normalizeThemeKey(array('django')));
         $this->assertNull(Manifest::palette(''));
         $this->assertNull(Manifest::palette('bogus'));
+    }
+
+    public function testSiteDefaultPrimaryFromCfgTheme()
+    {
+        global $CFG;
+        $CFG->theme = array('primary' => '#0a4b33');
+        $this->assertSame('#0a4b33', Manifest::siteDefaultPrimary());
+        $CFG->theme_base = '#7c3aed';
+        $this->assertSame('#7c3aed', Manifest::siteDefaultPrimary());
+        unset($CFG->theme_base, $CFG->theme);
+        $this->assertSame('#0D47A1', Manifest::siteDefaultPrimary());
     }
 
     public function testCurrentThemeKeyEmptyWithoutSession()

--- a/lib/tests/Core/ManifestTest.php
+++ b/lib/tests/Core/ManifestTest.php
@@ -143,6 +143,30 @@ class ManifestTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(1, $fake->gets);
     }
 
+    public function testCachedRowServesJsonAndThemeWithoutDatabase()
+    {
+        $json = Manifest::encode(Manifest::starter('Electric Course'));
+        $key = Manifest::cacheKey(77);
+        $fake = new ManifestTestMCache();
+        $fake->enabled = true;
+        $fake->store[$key] = array(
+            'manifest_id' => 77,
+            'theme' => 'electric',
+            'manifest' => $json,
+            'version' => 3,
+            'title' => 'Electric Course',
+        );
+        Manifest::setMCache($fake);
+        Manifest::rememberInSession(77);
+
+        $this->assertSame($json, Manifest::loadJson(77));
+        $this->assertSame('electric', Manifest::currentThemeKey());
+        $this->assertSame('#7c3aed', Manifest::currentThemeArray()['primary']);
+        Manifest::resetRequestCache();
+        $this->assertSame('electric', Manifest::currentThemeKey());
+        $this->assertSame($json, Manifest::loadJson(77));
+    }
+
     public function testLoadJsonDisabledCacheReturnsFalseWithoutDb()
     {
         $fake = new ManifestTestMCache();

--- a/lib/tests/UI/LessonsTest.php
+++ b/lib/tests/UI/LessonsTest.php
@@ -5,6 +5,12 @@ require_once "include/setup_i18n.php";
 require_once "src/UI/Lessons.php";
 require_once "src/Config/ConfigInfo.php";
 
+if (!function_exists('isLoggedIn')) {
+    function isLoggedIn() {
+        return !empty($_SESSION['id']);
+    }
+}
+
 /**
  * Simple tests for Lessons utility class
  * 
@@ -1648,6 +1654,49 @@ class LessonsTest extends \PHPUnit\Framework\TestCase
         $html = \Tsugi\UI\Lessons::resultLinkSignatureMarkup('pythonauto_01_hello', 12345);
         $this->assertStringContainsString('py345_61', $html);
         $this->assertStringContainsString('tsugi-assignments-rl-sig', $html);
+    }
+
+    public function testFromJsonMatchesFileConstructor() {
+        $path = __DIR__ . '/../fixtures/lessons/py4e-modern-lessons-items.json';
+        $fromFile = new \Tsugi\UI\Lessons($path);
+        $fromJson = \Tsugi\UI\Lessons::fromJson(file_get_contents($path));
+        $this->assertEquals($fromFile->lessons->title, $fromJson->lessons->title);
+        $this->assertEquals(count($fromFile->lessons->modules), count($fromJson->lessons->modules));
+        $this->assertEquals($fromFile->resource_links, $fromJson->resource_links);
+    }
+
+    public function testTryFromJsonReturnsLessonsOnSuccess() {
+        $json = json_encode(array(
+            'title' => 'Try Me',
+            'modules' => array(
+                array('title' => 'Week 1', 'anchor' => 'week-1', 'items' => array()),
+            ),
+        ));
+        $loaded = \Tsugi\UI\Lessons::tryFromJson($json);
+        $this->assertInstanceOf(\Tsugi\UI\Lessons::class, $loaded);
+        $this->assertSame('Try Me', $loaded->lessons->title);
+    }
+
+    public function testTryFromJsonReturnsMessageOnBadJson() {
+        $loaded = \Tsugi\UI\Lessons::tryFromJson('{');
+        $this->assertIsString($loaded);
+        $this->assertStringContainsString('parsing', $loaded);
+    }
+
+    public function testTryFromJsonReturnsMessageWhenModulesMissing() {
+        $loaded = \Tsugi\UI\Lessons::tryFromJson('{"title":"Nope"}');
+        $this->assertIsString($loaded);
+        $this->assertStringContainsString('modules', $loaded);
+    }
+
+    public function testApplyDiscussionOrder() {
+        $a = (object) array('title' => 'A', 'resource_link_id' => 'a');
+        $b = (object) array('title' => 'B', 'resource_link_id' => 'b');
+        $c = (object) array('title' => 'C', 'resource_link_id' => 'c');
+        $ordered = \Tsugi\UI\Lessons::applyDiscussionOrder(array($a, $b, $c), array('c', 'a'));
+        $this->assertSame(array('c', 'a', 'b'), array_map(function ($d) {
+            return $d->resource_link_id;
+        }, $ordered));
     }
 }
 


### PR DESCRIPTION
For existing Tsugi production with on-disk lessons.php - this remains latent because no one links to the /courses page and until a user is granted the new `create_courses` permission - which can be done by admin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Authorized users can create courses from the Courses area.
  - Instructors can add and reorder discussions, choose course themes, and import or export lesson content.
  - Course content can use versioned manifests while retaining support for existing lesson files.
- **Improvements**
  - Course-specific themes and content apply consistently across launches.
  - Administrators can search, sort, and configure course-creation access.
  - Added stronger protection for course and file-management forms.
- **Bug Fixes**
  - Improved handling and messaging when lesson content is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->