### PR TITLE
Require CSRF tokens on cookie-session mutating POSTs.

### DIFF
--- a/.github/workflows/test-class-loader.yml
+++ b/.github/workflows/test-class-loader.yml
@@ -31,12 +31,10 @@ jobs:
       - name: Lint PHP sources (exclude vendor)
         run: |
           php -l index.php
-          php -l login.php
-          php -l logout.php
           php -l top.php
           php -l tsugi.php
           php -l about.php
-          find admin api assertions cc cron dev ext gclass lms lti mod settings store util -name '*.php' -print0 | xargs -0 -n 1 php -l
+          find admin api assertions cc cron dev ext gclass lti mod settings store util -name '*.php' -print0 | xargs -0 -n 1 php -l
 
       - name: PHPStan (dead code + array shape)
         run: vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G --no-progress

--- a/admin/blob_clean.php
+++ b/admin/blob_clean.php
@@ -38,34 +38,38 @@ since it is a long running task.
 <?php } ?>
 <?php
 if ( U::get($_POST,'migrate') ) {
-    $start = time();
-    $files = $PDOX->allRowsDie("SELECT BB.blob_id, BB.blob_sha256
-        FROM {$CFG->dbprefix}blob_blob AS BB 
-        LEFT JOIN {$CFG->dbprefix}blob_file AS BF 
-            ON BB.blob_sha256 = BF.file_sha256 AND BB.blob_id = BF.blob_id
-        WHERE BF.blob_id IS NULL LIMIT 100");
+    if ( ! \Tsugi\Controllers\Tool::checkCsrf() ) {
+        echo("<p>Missing or invalid CSRF token</p>\n");
+    } else {
+        $start = time();
+        $files = $PDOX->allRowsDie("SELECT BB.blob_id, BB.blob_sha256
+            FROM {$CFG->dbprefix}blob_blob AS BB 
+            LEFT JOIN {$CFG->dbprefix}blob_file AS BF 
+                ON BB.blob_sha256 = BF.file_sha256 AND BB.blob_id = BF.blob_id
+            WHERE BF.blob_id IS NULL LIMIT 100");
 
-    echo("<pre>\n");
-    foreach ( $files as $row ) {
-        $blob_id = $row['blob_id'];
-        $blob_sha256 = $row['blob_sha256'];
-        if ( ! $blob_id ) continue;
+        echo("<pre>\n");
+        foreach ( $files as $row ) {
+            $blob_id = $row['blob_id'];
+            $blob_sha256 = $row['blob_sha256'];
+            if ( ! $blob_id ) continue;
 
-        $stmt = $PDOX->prepare("DELETE FROM {$CFG->dbprefix}blob_blob
-            WHERE blob_id = :ID");
-        $stmt->execute(array(':ID' => $blob_id));
+            $stmt = $PDOX->prepare("DELETE FROM {$CFG->dbprefix}blob_blob
+                WHERE blob_id = :ID");
+            $stmt->execute(array(':ID' => $blob_id));
 
-        $note = "Unreferenced blob removed blob_id=$blob_id sha=$blob_sha256";
-        error_log($note);
-        echo("$note\n");
+            $note = "Unreferenced blob removed blob_id=$blob_id sha=$blob_sha256";
+            error_log($note);
+            echo("$note\n");
 
-        $delta = time() - $start;
-        if ( $delta > 10 ) {
-            echo("Migration stopped at 10 seconds ellapsed time\n");
-            break;
+            $delta = time() - $start;
+            if ( $delta > 10 ) {
+                echo("Migration stopped at 10 seconds ellapsed time\n");
+                break;
+            }
         }
+        echo("</pre>\n");
     }
-    echo("</pre>\n");
 }
 
 $row = $PDOX->rowDie("SELECT count(BB.blob_id) AS count
@@ -81,6 +85,7 @@ $file_count = $row ? $row['count'] : 0;
 <?php if ( $file_count > 0 ) { ?>
 <p>
 <form method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <input type="submit" onclick="$('#myspinner').show();return true;" name="migrate" value="Delete Blobs"/>
 <input type="submit" onclick="$('#myspinner').show();return true;" name="reset" value="Clear Results"/>
 <img id="myspinner" src="<?= $OUTPUT->getSpinnerUrl() ?>" alt="" role="presentation" style="display:none">

--- a/admin/blob_move.php
+++ b/admin/blob_move.php
@@ -41,33 +41,37 @@ $where = "path IS NULL AND blob_id IS NULL"; // Leave disk blobs alone
 if ( $todisk ) $where = "path IS NULL";
 
 if ( U::get($_POST,'migrate') ) {
-    $start = time();
-    $files = $PDOX->allRowsDie("SELECT file_id, context_id FROM {$CFG->dbprefix}blob_file WHERE $where LIMIT 100");
-    echo("<pre>\n");
-    foreach ( $files as $row ) {
-        $id = $row['file_id'];
-        $context_id = $row['context_id'];
-        if ( ! $id ) continue;
-        $test_key = BlobUtil::isTestKey($context_id);
-        $retval = BlobUtil::migrate($id, $test_key);
-        if ( is_string($retval) ) {
-            echo("Could not Migrate file_id=$id ".htmlentities($retval)."\n");
-            break;
+    if ( ! \Tsugi\Controllers\Tool::checkCsrf() ) {
+        echo("<p>Missing or invalid CSRF token</p>\n");
+    } else {
+        $start = time();
+        $files = $PDOX->allRowsDie("SELECT file_id, context_id FROM {$CFG->dbprefix}blob_file WHERE $where LIMIT 100");
+        echo("<pre>\n");
+        foreach ( $files as $row ) {
+            $id = $row['file_id'];
+            $context_id = $row['context_id'];
+            if ( ! $id ) continue;
+            $test_key = BlobUtil::isTestKey($context_id);
+            $retval = BlobUtil::migrate($id, $test_key);
+            if ( is_string($retval) ) {
+                echo("Could not Migrate file_id=$id ".htmlentities($retval)."\n");
+                break;
+            }
+            if ( $retval == true ) {
+                echo("File migrated file_id=$id\n");
+                error_log("File migrated file_id=$id");
+            } else {
+                echo("File did not migrate file_id=$id\n");
+                error_log("File did not migrate file_id=$id");
+            }
+            $delta = time() - $start;
+            if ( $delta > 10 ) {
+                echo("Migration stopped at 10 seconds ellapsed time\n");
+                break;
+            }
         }
-        if ( $retval == true ) {
-            echo("File migrated file_id=$id\n");
-            error_log("File migrated file_id=$id");
-        } else {
-            echo("File did not migrate file_id=$id\n");
-            error_log("File did not migrate file_id=$id");
-        }
-        $delta = time() - $start;
-        if ( $delta > 10 ) {
-            echo("Migration stopped at 10 seconds ellapsed time\n");
-            break;
-        }
+        echo("</pre>\n");
     }
-    echo("</pre>\n");
 }
 
 $row = $PDOX->rowDie("SELECT count(file_id) AS count FROM {$CFG->dbprefix}blob_file WHERE $where");
@@ -79,6 +83,7 @@ $file_count = $row ? $row['count'] : 0;
 <?php if ( $file_count > 0 ) { ?>
 <p>
 <form method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <input type="submit" onclick="$('#myspinner').show();return true;" name="migrate" value="Migrate Blobs"/>
 <input type="submit" onclick="$('#myspinner').show();return true;" name="reset" value="Clear Results"/>
 <img id="myspinner" src="<?= $OUTPUT->getSpinnerUrl() ?>" alt="" role="presentation" style="display:none">

--- a/admin/cache.php
+++ b/admin/cache.php
@@ -9,6 +9,10 @@ if ( $REDIRECTED === true || ! isset($_SESSION["admin"]) ) return;
 use \Tsugi\Util\U;
 use \Tsugi\UI\Output;
 
+if ( $_SERVER['REQUEST_METHOD'] === 'POST' ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(U::addSession('cache.php')) ) return;
+}
+
 if (U::isKeyNotEmpty($_POST, "set") && U::isKeyNotEmpty($_POST, "set_value")) {
     U::appCacheSet('tsugi_test', U::get($_POST, "set_value"));
 }
@@ -37,6 +41,7 @@ if ( U::apcuAvailable() ) {
     }
 ?>
 <form method="POST">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <input type="submit" name="set" value="Set tsugi_test cache entry"> = 
 <input type="text" name="set_value"><br/>
 <input type="submit" name="delete" value="Delete tsugi_test cache entry"><br/>

--- a/admin/context/bulk-mail.php
+++ b/admin/context/bulk-mail.php
@@ -122,6 +122,10 @@ $context_title = $context_row['title'] ? $context_row['title'] : "Context #$cont
 $from_user_id = loggedInUserId();
 $step = U::get($_REQUEST, 'step', 'compose');
 
+if ( $_SERVER['REQUEST_METHOD'] === 'POST' ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect('bulk-mail.php?context_id='.$context_id) ) return;
+}
+
 // ---------- Send (confirm POST) ----------
 if ( $_SERVER['REQUEST_METHOD'] === 'POST' && U::get($_POST, 'step') === 'send' ) {
     if ( (!isset($CFG->maildomain)) || $CFG->maildomain === false ) {
@@ -464,6 +468,7 @@ Transport: <strong><?= htmlentities(MailService::transport()) ?></strong>
   <div class="panel-heading"><h3 class="panel-title">Compose</h3></div>
   <div class="panel-body">
     <form method="post" action="bulk-mail.php">
+      <?= \Tsugi\Controllers\Tool::csrfField() ?>
       <input type="hidden" name="context_id" value="<?= (int) $context_id ?>">
       <input type="hidden" name="step" value="compose">
       <div class="form-group">
@@ -722,6 +727,7 @@ $cli_preview = bulk_mail_cli_instructions(
 
     <?php if ( $mail_ok && !$over && $n > 0 ) { ?>
     <form method="post" action="bulk-mail.php" style="margin-top:15px;">
+      <?= \Tsugi\Controllers\Tool::csrfField() ?>
       <input type="hidden" name="context_id" value="<?= (int) $context_id ?>">
       <input type="hidden" name="step" value="send">
       <input type="hidden" name="subject" value="<?= htmlentities($subject) ?>">

--- a/admin/context/context-settings.php
+++ b/admin/context/context-settings.php
@@ -27,6 +27,7 @@ $context_id = $_REQUEST['context_id'];
 
 // Handle POST - save settings (must be done BEFORE any output)
 if ( isset($_POST['settings_json']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(U::addSession("context-settings.php?context_id=".$context_id)) ) return;
     $settings_json = trim($_POST['settings_json']);
     
     // Validate JSON if not empty
@@ -113,6 +114,7 @@ $OUTPUT->flashMessages();
 <h2><?= htmlentities($context_title) ?></h2>
 
 <form method="post">
+    <?= \Tsugi\Controllers\Tool::csrfField() ?>
     <div class="form-group">
         <label for="settings_json">Context Settings (JSON)</label>
         <textarea class="form-control" id="settings_json" name="settings_json" rows="20" 

--- a/admin/context/mailing-list.php
+++ b/admin/context/mailing-list.php
@@ -29,6 +29,7 @@ $context_id = $_REQUEST['context_id'] + 0;
 
 // Handle form submission - POST-Redirect-GET pattern
 if ( $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['days']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect('mailing-list.php?context_id='.$context_id) ) return;
     $days = $_POST['days'] + 0;
     if ( !is_numeric($_POST['days']) || $days < 1 || $days > 365 ) {
         U::flashError("Days must be between 1 and 365");
@@ -137,6 +138,7 @@ $OUTPUT->flashMessages();
   <div class="panel-body">
     <p>Generate a mailing list of users who have logged in within a specified number of days.</p>
     <form method="post" action="mailing-list.php">
+      <?= \Tsugi\Controllers\Tool::csrfField() ?>
       <input type="hidden" name="context_id" value="<?= htmlentities($context_id) ?>">
       <div class="form-group" style="margin-bottom: 15px;">
         <label for="days">Users who logged in within the last:</label>

--- a/admin/crypt.php
+++ b/admin/crypt.php
@@ -15,6 +15,10 @@ $encrypted_result = null;
 $decrypted_result = null;
 $error_message = null;
 
+if ( $_SERVER['REQUEST_METHOD'] === 'POST' ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(U::addSession('crypt.php')) ) return;
+}
+
 // Handle encryption
 if (U::isKeyNotEmpty($_POST, "encrypt") && U::isKeyNotEmpty($_POST, "encrypt_value")) {
     $plaintext = U::get($_POST, "encrypt_value");
@@ -185,6 +189,7 @@ input[type="submit"]:hover {
 <div class="form-section">
 <h2>Encrypt String</h2>
 <form method="POST" autocomplete="off">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <label for="encrypt_value">Enter plaintext to encrypt:</label><br/>
 <textarea name="encrypt_value" id="encrypt_value" placeholder="Enter text to encrypt..."><?= htmlentities(U::get($_POST, "encrypt_value", "")) ?></textarea><br/>
 <label for="encrypt_secret">Secret (optional - if provided, uses AesOpenSSL::encrypt):</label><br/>
@@ -202,6 +207,7 @@ input[type="submit"]:hover {
 <div class="form-section">
 <h2>Decrypt String</h2>
 <form method="POST" autocomplete="off">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <label for="decrypt_value">Enter encrypted string to decrypt:</label><br/>
 <textarea name="decrypt_value" id="decrypt_value" placeholder="Enter encrypted text (e.g., AES::...)..."><?= htmlentities(U::get($_POST, "decrypt_value", "")) ?></textarea><br/>
 <label for="decrypt_secret">Secret (optional - if provided, uses AesCtr::decrypt):</label><br/>

--- a/admin/expire/login-expire.php
+++ b/admin/expire/login-expire.php
@@ -68,6 +68,7 @@ $params = array_merge($where_data['params'], $where_params);
 $sql_display = \Tsugi\Util\PDOX::sqlDisplay($sql, $params);
 
 if ( isset($_POST['doDelete']) && isset($_POST['days']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(U::addSession($_SERVER['REQUEST_URI'])) ) return;
     echo("<pre>\n");
     $start = time();
 
@@ -92,6 +93,7 @@ since last login:
 <?= htmlspecialchars($sql_display) ?>
 </pre>
 <form method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <input type="hidden" name="days" value="<?= $days ?>">
 <input type="submit" name="doDelete" value="Delete <?= $count ?> <?= htmlentities(ucfirst($base)) ?>s and All Associated Data">
 </form>

--- a/admin/expire/pii-expire.php
+++ b/admin/expire/pii-expire.php
@@ -42,6 +42,7 @@ $params = $where['params'];
 $sql_display = \Tsugi\Util\PDOX::sqlDisplay($sql, $params);
 
 if ( isset($_POST['doDelete']) && isset($_POST['pii_days']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(U::addSession($_SERVER['REQUEST_URI'])) ) return;
     echo("<pre>\n");
     $start = time();
 
@@ -66,6 +67,7 @@ using the following SQL:
 <?= htmlspecialchars($sql_display) ?>
 </pre>
 <form method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <input type="hidden" name="pii_days" value="<?= $days ?>">
 <input type="submit" name="doDelete" value="Delete PII for <?= $pii_count ?> Users">
 </form>

--- a/admin/external/ext-add.php
+++ b/admin/external/ext-add.php
@@ -33,6 +33,10 @@ $titles = array(
     'json' => 'Additional settings for your tool registration (see below)'
 );
 
+if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(U::addsession($from_location)) ) return;
+}
+
 if ( U::get($_POST,'endpoint') ) {
     if ( strlen(U::get($_POST,'pubkey')) < 1 && strlen(U::get($_POST,'privkey')) < 1 ) {
         /** @var true|string $success */

--- a/admin/external/ext-detail.php
+++ b/admin/external/ext-detail.php
@@ -38,6 +38,10 @@ $titles = array(
 );
 
 // Handle the post data
+if ( isset($_POST['doUpdate']) || isset($_POST['doDelete']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(U::addsession($from_location)) ) return;
+}
+
 if ( U::get($_POST,'endpoint') ) {
     if ( strlen(U::get($_POST,'pubkey')) < 1 || strlen(U::get($_POST,'privkey'))) {
         /** @var true|string $success */

--- a/admin/gate.php
+++ b/admin/gate.php
@@ -34,6 +34,14 @@ if ( $havedatabase && $CFG->google_client_id && ! isLoggedIn() ) {
 }
 
 if ( isset($_POST['passphrase']) ) {
+    if ( ! \Tsugi\Controllers\Tool::csrfOk() ) {
+        U::flashError('Missing or invalid CSRF token');
+        $rest_path = \Tsugi\Util\U::rest_path();
+        $redirect = U::addSession(U::reconstruct_query($rest_path->current));
+        Output::doRedirect($redirect);
+        $REDIRECTED = true;
+        return;
+    }
     unset($_SESSION["admin"]);
     $apw = $CFG->adminpw;
     $phrase = $_POST['passphrase'];
@@ -64,6 +72,7 @@ $OUTPUT->bodyStart();
 $OUTPUT->topNav();
 ?>
 <form method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <label for="passphrase">Admin Unlock:<br/>
 <input type="password" autocomplete="off" name="passphrase" size="80">
 </label>

--- a/admin/gate.php
+++ b/admin/gate.php
@@ -50,6 +50,7 @@ if ( isset($_POST['passphrase']) ) {
        (strpos($apw, 'sha256:') === 0 && $hash == $apw ) ) {
 
         $_SESSION["admin"] = "yes";
+        session_regenerate_id(true);
         error_log("Admin login IP=".$_SERVER["REMOTE_ADDR"].
             (isLoggedIn() ? " id=".loggedInUserId().' email='.U::get($_SESSION, 'email', '') : " developer mode"));
     } else {
@@ -70,8 +71,9 @@ if ( isset($_SESSION['admin']) ) return;
 $OUTPUT->header();
 $OUTPUT->bodyStart();
 $OUTPUT->topNav();
+$OUTPUT->flashMessages();
 ?>
-<form method="post">
+<form method="post" action="<?= htmlspecialchars($CFG->wwwroot) ?>/admin/">
 <?= \Tsugi\Controllers\Tool::csrfField() ?>
 <label for="passphrase">Admin Unlock:<br/>
 <input type="password" autocomplete="off" name="passphrase" size="80">

--- a/admin/index.php
+++ b/admin/index.php
@@ -5,7 +5,6 @@ use \Tsugi\Util\U;
 if ( ! defined('COOKIE_SESSION') ) define('COOKIE_SESSION', true);
 require_once("../config.php");
 session_start();
-session_regenerate_id(true);
 require_once("gate.php");
 if ( $REDIRECTED === true || ! isset($_SESSION["admin"]) ) return;
 

--- a/admin/install/git.php
+++ b/admin/install/git.php
@@ -145,6 +145,10 @@ if ( $command == 'pull' ) {
 }
 
 // Handle the pull POST - do the actual work
+if ( isset($_POST['command']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('git.php')) ) return;
+}
+
 if ( isset($_POST['command']) && $command == "pull" ) {
     $path = $paths[$_REQUEST['path']];
 
@@ -246,6 +250,7 @@ $OUTPUT->flashMessages();
 if ( $command == 'pull' ) {
 ?>
 <form method="POST">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>
 Git Command: <?= htmlentities($command) ?>
 </p><p>
@@ -259,6 +264,7 @@ Git Repository: <?= htmlentities($origin) ?>
 } else if ( $command == 'clone' ) {
 ?>
 <form method="POST">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>
 Git Command: <?= htmlentities($command) ?>
 </p><p>

--- a/admin/key/approve-key.php
+++ b/admin/key/approve-key.php
@@ -52,6 +52,10 @@ $token = Mail::computeCheck($user_id);
 $to = $row['email'];
 
 // Handle post
+if ( isset($_POST['doReject']) || isset($_POST['doApprove']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect($from_location) ) return;
+}
+
 if ( isset($_POST['doReject']) && isset($_POST['request_id']) ) {
     $PDOX->queryDie(
         "UPDATE {$CFG->dbprefix}key_request SET state=2 WHERE request_id = :rid",
@@ -137,6 +141,7 @@ $OUTPUT->flashMessages();
 
 ?>
 <form method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <input type="submit" name="doApprove" class="btn btn-warning" value="<?= _m("Approve") ?>"
   onclick="return confirm('Are you sure you want to approve this request?');">
 <input type="submit" name="doReject" class="btn btn-danger" value="<?= _m("Reject") ?>"

--- a/admin/key/key-add.php
+++ b/admin/key/key-add.php
@@ -47,6 +47,10 @@ $titles = array(
 	'lms_token_audience' => 'LTI 1.3 Platform Audience (optional)',
 );
 
+if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect('key-add') ) return;
+}
+
 if ( isset($_POST['key_key']) && empty($_POST['key_key']) ) $_POST['key_key'] = null;
 if ( isset($_POST['user_id']) && empty($_POST['user_id']) && isLoggedIn() ) $_POST['user_id'] = loggedInUserId();
 

--- a/admin/key/key-detail.php
+++ b/admin/key/key-detail.php
@@ -52,6 +52,10 @@ $titles = array(
     'unlock_code' => 'LTI 1.3: Dynamic Registration Unlock Code (one time use)',
 );
 
+if ( isset($_POST['doUpdate']) || isset($_POST['doDelete']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect($from_location) ) return;
+}
+
 if ( isset($_POST['key_key']) && empty($_POST['key_key']) ) $_POST['key_key'] = null;
 if ( isset($_POST['user_id']) && empty($_POST['user_id']) ) $_POST['user_id'] = null;
 if ( isset($_POST['deploy_key']) ) {

--- a/admin/key/key-settings.php
+++ b/admin/key/key-settings.php
@@ -30,6 +30,7 @@ $key_id = $_REQUEST['key_id'];
 
 // Handle POST - save settings (must be done BEFORE any output)
 if ( isset($_POST['settings_json']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(U::addSession("key-settings.php?key_id=".$key_id)) ) return;
     $settings_json = trim($_POST['settings_json']);
     
     // Validate JSON if not empty
@@ -116,6 +117,7 @@ $OUTPUT->flashMessages();
 <h2><?= htmlentities($key_title) ?></h2>
 
 <form method="post">
+    <?= \Tsugi\Controllers\Tool::csrfField() ?>
     <div class="form-group">
         <label for="settings_json">Key Settings (JSON)</label>
         <textarea class="form-control" id="settings_json" name="settings_json" rows="20" 

--- a/admin/keyset.php
+++ b/admin/keyset.php
@@ -10,6 +10,10 @@ use \Tsugi\Util\U;
 use \Tsugi\UI\Output;
 use \Tsugi\Core\Keyset;
 
+if ( $_SERVER['REQUEST_METHOD'] === 'POST' ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(U::addSession('keyset.php')) ) return;
+}
+
 if (U::isKeyNotEmpty($_POST, "maintain") ) {
     Keyset::maintain();
 }
@@ -41,6 +45,7 @@ $kid = U::appCacheGet('keyset_kid', null);
 <a href="<?= $keyset_url ?>" target="_blank"><?= $keyset_url ?></a>
 </p>
 <form method="POST">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <input type="submit" name="maintain" value="Maintain / Check for Key Rotation">
 <input type="submit" name="getkey" value="Retrieve Signing Key">
 </form>

--- a/admin/mail/purge_util.php
+++ b/admin/mail/purge_util.php
@@ -71,6 +71,7 @@ function mail_admin_purge_form($action_url, $table, $label) {
   <?php if ( $old > 0 ) { ?>
   <form method="post" action="<?= htmlentities($action_url) ?>" style="display:inline;margin-left:8px;"
         onsubmit="return confirm(<?= htmlentities(json_encode($confirm), ENT_QUOTES) ?>);">
+    <?= \Tsugi\Controllers\Tool::csrfField() ?>
     <input type="hidden" name="purge_old" value="1">
     <input type="hidden" name="confirm_purge" value="1">
     <button type="submit" class="btn btn-danger btn-xs">Purge</button>
@@ -125,6 +126,7 @@ function mail_admin_delete_delivery_events_form($action_url) {
   <?php if ( $n > 0 ) { ?>
   <form method="post" action="<?= htmlentities($action_url) ?>" style="display:inline;margin-left:8px;"
         onsubmit="return confirm(<?= htmlentities(json_encode($confirm), ENT_QUOTES) ?>);">
+    <?= \Tsugi\Controllers\Tool::csrfField() ?>
     <input type="hidden" name="delete_delivery_events" value="1">
     <input type="hidden" name="confirm_delete_delivery" value="1">
     <button type="submit" class="btn btn-warning btn-xs">Delete delivery events</button>

--- a/admin/mail/sent.php
+++ b/admin/mail/sent.php
@@ -22,6 +22,10 @@ if ( ! isAdmin() ) {
 
 $fields = $PDOX->metadata($CFG->dbprefix . 'mail_sent');
 
+if ( $_SERVER['REQUEST_METHOD'] === 'POST' ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect('sent') ) return;
+}
+
 if ( $_SERVER['REQUEST_METHOD'] === 'POST' && U::get($_POST, 'purge_old') ) {
     if ( ! U::get($_POST, 'confirm_purge') ) {
         U::flashError('You must confirm the purge');

--- a/admin/mail/ses-events.php
+++ b/admin/mail/ses-events.php
@@ -21,6 +21,10 @@ if ( ! isAdmin() ) {
     return;
 }
 
+if ( $_SERVER['REQUEST_METHOD'] === 'POST' ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect('ses-events') ) return;
+}
+
 if ( $_SERVER['REQUEST_METHOD'] === 'POST' && U::get($_POST, 'purge_old') ) {
     if ( ! U::get($_POST, 'confirm_purge') ) {
         U::flashError('You must confirm the purge');

--- a/admin/mcache.php
+++ b/admin/mcache.php
@@ -15,6 +15,7 @@ $mc = $cache->getMemcached();
 
 $result_html = '';
 if ( $cache->isEnabled() && $_SERVER['REQUEST_METHOD'] === 'POST' ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(U::addSession('mcache.php')) ) return;
     $op = U::get($_POST, 'mcache_op', '');
     $key = trim((string) U::get($_POST, 'mcache_key', ''));
     if ( U::strlen($op) < 1 ) {
@@ -114,6 +115,7 @@ if ( ! $cache->isEnabled() ) {
 ?>
 <h2>Get / set / delete</h2>
 <form method="POST">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <fieldset>
 <legend>Key and value</legend>
 <label>Key<br/>

--- a/admin/testmail.php
+++ b/admin/testmail.php
@@ -12,6 +12,7 @@ use \Tsugi\Services\Mail\MailService;
 LTIX::getConnection();
 
 if ( U::get($_POST,'email') && U::get($_POST,'subject') && U::get($_POST,'body')) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(U::addSession('testmail.php')) ) return;
     $to = trim((string) U::get($_POST,'email'));
     $subject = (string) U::get($_POST,'subject');
     $body = (string) U::get($_POST,'body');
@@ -133,6 +134,7 @@ maildomain:
 </p>
 <p>
 <form method="POST">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>
 Mail address:<br/>
 <input style="width: 90%" type="email" name="email">

--- a/api/settings.php
+++ b/api/settings.php
@@ -12,6 +12,12 @@ if ( Rest::preFlight() ) return;
 
 $LAUNCH = LTIX::requireData();
 
+if ( ! \Tsugi\Controllers\Tool::csrfOk() ) {
+    http_response_code(403);
+    echo json_encode(array('error' => 'Missing or invalid CSRF token'));
+    return;
+}
+
 // Takes raw data from the request
 $json = file_get_contents('php://input');
 $data = json_decode($json);

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
         "platform-check": false
     },
     "scripts": {
-        "lint": "php -l index.php && php -l login.php && php -l logout.php && php -l top.php && php -l tsugi.php && php -l about.php && find admin api assertions cc cron dev ext gclass lms lti mod settings store util -name '*.php' -print0 | xargs -0 -n 1 php -l",
+        "lint": "php -l index.php && php -l top.php && php -l tsugi.php && php -l about.php && find admin api assertions cc cron dev ext gclass lti mod settings store util -name '*.php' -print0 | xargs -0 -n 1 php -l",
         "phpstan": "phpstan analyse -c phpstan.neon --memory-limit=1G --no-progress",
         "finalize-vendor": "bash qa/finalize-vendor.sh",
         "post-update-cmd": "@finalize-vendor"

--- a/lib/src/Controllers/Announcements.php
+++ b/lib/src/Controllers/Announcements.php
@@ -355,6 +355,7 @@ class Announcements extends Tool {
                     
                     fetch(url, {
                         method: 'POST',
+                        headers: tsugiCsrfHeaders(),
                         body: formData
                     })
                     .then(response => response.json())
@@ -470,7 +471,8 @@ class Announcements extends Tool {
                     var url = this.getAttribute('data-url');
                     
                     fetch(url, {
-                        method: 'POST'
+                        method: 'POST',
+                        headers: tsugiCsrfHeaders()
                     })
                     .then(response => response.json())
                     .then(data => {
@@ -625,6 +627,10 @@ class Announcements extends Tool {
         if ($request->getMethod() !== 'POST') {
             return new JsonResponse(['status' => 'error', 'detail' => 'Method not allowed'], 405);
         }
+        $csrf = self::requireCsrfJson();
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         // Get POST data - FormData from fetch() should populate $_POST
         // But Symfony Request might consume the body, so check both
@@ -729,6 +735,10 @@ class Announcements extends Tool {
         if ($request->getMethod() !== 'POST') {
             return new JsonResponse(['status' => 'error', 'detail' => 'Method not allowed'], 405);
         }
+        $csrf = self::requireCsrfJson();
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         $user_id = U::loggedInUserId();
         $context_id = U::currentContextId();
@@ -813,6 +823,7 @@ class Announcements extends Tool {
                 </div>
                 <div class="panel-body">
                     <form method="POST" action="<?= $add_url ?>">
+                        <?= self::csrfField() ?>
                         <div class="form-group">
                             <label for="title">Title *</label>
                             <input type="text" class="form-control" id="title" name="title" 
@@ -868,6 +879,10 @@ class Announcements extends Tool {
         $tool_home = $this->toolHome(self::ROUTE);
         $add_url = $tool_home . '/add';
         $manage_url = $tool_home . '/manage';
+        $csrf = self::requireCsrf($add_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         LTIX::getConnection();
         
@@ -972,6 +987,7 @@ class Announcements extends Tool {
                 </div>
                 <div class="panel-body">
                     <form method="POST" action="<?= $edit_url ?>">
+                        <?= self::csrfField() ?>
                         <div class="form-group">
                             <label for="title">Title *</label>
                             <input type="text" class="form-control" id="title" name="title" 
@@ -1032,6 +1048,10 @@ class Announcements extends Tool {
         
         $tool_home = $this->toolHome(self::ROUTE);
         $manage_url = $tool_home . '/manage';
+        $csrf = self::requireCsrf($manage_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         LTIX::getConnection();
         
@@ -1183,6 +1203,7 @@ class Announcements extends Tool {
                                         <?php $manage_url = $tool_home . '/manage'; ?>
                                         <?php if ($pub === 0 || ($publish_at && strtotime($publish_at) > time())): ?>
                                         <form method="POST" action="<?= $manage_url ?>" style="display: inline-block;">
+                                            <?= self::csrfField() ?>
                                             <input type="hidden" name="action" value="publish">
                                             <input type="hidden" name="announcement_id" value="<?= htmlspecialchars($announcement['announcement_id']) ?>">
                                             <button type="submit" class="btn btn-sm btn-success">Publish</button>
@@ -1191,6 +1212,7 @@ class Announcements extends Tool {
                                         <form method="POST" action="<?= $manage_url ?>" 
                                               style="display: inline-block;" 
                                               onsubmit="return confirm('Are you sure you want to delete this announcement?');">
+                                            <?= self::csrfField() ?>
                                             <input type="hidden" name="action" value="delete">
                                             <input type="hidden" name="announcement_id" value="<?= htmlspecialchars($announcement['announcement_id']) ?>">
                                             <button type="submit" class="btn btn-sm btn-danger">Delete</button>
@@ -1215,6 +1237,10 @@ class Announcements extends Tool {
         
         $tool_home = $this->toolHome(self::ROUTE);
         $manage_url = $tool_home . '/manage';
+        $csrf = self::requireCsrf($manage_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         LTIX::getConnection();
         

--- a/lib/src/Controllers/Assignments.php
+++ b/lib/src/Controllers/Assignments.php
@@ -135,6 +135,7 @@ class Assignments extends Tool {
                 $btnLabel = $hiding ? __('Show due dates') : __('Hide due dates');
                 $toggleAction = U::addSession($this->toolHome(self::ROUTE) . '/toggle-view-due-dates');
                 echo('<form method="post" action="'.htmlspecialchars($toggleAction).'" style="display:inline;margin:0;">');
+                echo(self::csrfField());
                 echo('<button type="submit" class="btn btn-default btn-sm">'.htmlspecialchars($btnLabel).'</button>');
                 echo('</form>');
             }
@@ -317,11 +318,16 @@ class Assignments extends Tool {
             die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireAuth();
+        $home = U::addSession($this->toolHome(self::ROUTE));
+        $csrf = self::requireCsrf($home);
+        if ( $csrf ) {
+            return $csrf;
+        }
         $context_id = U::currentContextId();
         $user_id = U::loggedInUserId();
         if ( ! $context_id || ! $user_id ) {
             U::flashError(__('Context required.'));
-            return new RedirectResponse(U::addSession($this->toolHome(self::ROUTE)));
+            return new RedirectResponse($home);
         }
         $cid = (int) $context_id;
         $uid = (int) $user_id;
@@ -412,6 +418,7 @@ class Assignments extends Tool {
             echo(__('The resource link id in your lessons file must match the LMS resource link id when students launch, or launches will create a different row.'));
             echo('</p>');
             echo('<form method="post" action="'.htmlspecialchars($addLinksAction).'">');
+            echo(self::csrfField());
             echo('<button type="submit" class="btn btn-default">');
             echo('<i class="fa fa-plus-circle" aria-hidden="true"></i> '.__('Add missing link rows').' ('.$missingCount.')');
             echo('</button>');
@@ -424,6 +431,7 @@ class Assignments extends Tool {
         echo('<p><strong>'.__('Weekly due dates').'</strong></p>');
         echo('<p>'.__('Lesson modules are ordered as in your lessons file. Pick the due date for all assignments in the first module (week 1). Each later module adds one week; every due is 11:59 PM on that calendar day.').'</p>');
         echo('<form method="post" action="'.htmlspecialchars($weeklyAction).'" class="form-inline">');
+        echo(self::csrfField());
         echo('<div class="form-group" style="margin-right:1em;">');
         echo('<label for="week1_due" style="margin-right:0.5em;">'.__('First module due date').'</label> ');
         echo('<input type="date" class="form-control" id="week1_due" name="week1_due" required>');
@@ -439,6 +447,7 @@ class Assignments extends Tool {
         echo('<p>'.__('Sets due date to empty for every lesson assignment that has an LTI link row in this course.').'</p>');
         echo('<form method="post" action="'.htmlspecialchars($clearAllAction).'" onsubmit=\'return confirm('.
             json_encode(__('Remove all due dates for lesson assignments in this course?')).');\'>');
+        echo(self::csrfField());
         echo('<button type="submit" class="btn btn-warning">');
         echo('<i class="fa fa-eraser" aria-hidden="true"></i> '.__('Clear all due dates'));
         echo('</button>');
@@ -446,6 +455,7 @@ class Assignments extends Tool {
         echo('</div>');
 
         echo('<form method="post" action="'.htmlspecialchars($action).'" class="table-responsive">'."\n");
+        echo(self::csrfField());
         echo('<table class="table table-bordered table-striped">'."\n");
         echo('<thead><tr><th>'.__('Module').'</th><th>'.__('Assignment').'</th><th>'.__('Resource link').'</th><th>'.__('Due date').'</th></tr></thead>'."\n");
         echo("<tbody>\n");
@@ -494,6 +504,11 @@ class Assignments extends Tool {
             die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
+        $dates_url = U::addSession($this->toolHome(self::ROUTE) . '/manage-due-dates');
+        $csrf = self::requireCsrf($dates_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
 
         $context_id = U::currentContextId();
         $l = Manifest::requireCurrentLessons();
@@ -561,6 +576,11 @@ class Assignments extends Tool {
             die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
+        $dates_url = U::addSession($this->toolHome(self::ROUTE) . '/manage-due-dates');
+        $csrf = self::requireCsrf($dates_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
 
         $context_id = U::currentContextId();
         $l = Manifest::requireCurrentLessons();
@@ -604,6 +624,11 @@ class Assignments extends Tool {
             die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
+        $dates_url = U::addSession($this->toolHome(self::ROUTE) . '/manage-due-dates');
+        $csrf = self::requireCsrf($dates_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
 
         $context_id = U::currentContextId();
         $raw = U::get($_POST, 'week1_due', '');
@@ -678,6 +703,11 @@ class Assignments extends Tool {
             die_with_error_log('Cannot find lessons.json ($CFG->lessons) or an active course manifest');
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
+        $dates_url = U::addSession($this->toolHome(self::ROUTE) . '/manage-due-dates');
+        $csrf = self::requireCsrf($dates_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
 
         $context_id = U::currentContextId();
         $l = Manifest::requireCurrentLessons();

--- a/lib/src/Controllers/Discussions.php
+++ b/lib/src/Controllers/Discussions.php
@@ -88,6 +88,7 @@ class Discussions extends Tool {
             <h1><?= __('Add discussion') ?></h1>
             <p><?= __('Creates a new discussion in this course and saves it as a new manifest version.') ?></p>
             <form method="post" action="<?= htmlspecialchars(U::addSession($this->toolHome(self::ROUTE) . '/add')) ?>">
+                <?= self::csrfField() ?>
                 <p>
                     <label for="discussion_title"><?= __('Title') ?></label><br/>
                     <input type="text" id="discussion_title" name="title" required maxlength="512" style="min-width: 20em;"/>
@@ -113,6 +114,10 @@ class Discussions extends Tool {
         $gate = $this->addDiscussionGate($list_url);
         if ( $gate ) {
             return $gate;
+        }
+        $csrf = self::requireCsrf($form_url);
+        if ( $csrf ) {
+            return $csrf;
         }
 
         $title = trim((string) U::get($_POST, 'title', ''));
@@ -263,7 +268,12 @@ class Discussions extends Tool {
                 var barBtn = document.getElementById('tsugi-reorder-save-bar-btn');
                 if (btn) btn.disabled = true;
                 if (barBtn) barBtn.disabled = true;
-                jQuery.post(saveUrl, { order: collectOrder() })
+                jQuery.ajax({
+                    url: saveUrl,
+                    method: 'POST',
+                    data: { order: collectOrder() },
+                    headers: tsugiCsrfHeaders()
+                })
                     .done(function(data) {
                         allowLeave = true;
                         hasChanges = false;
@@ -333,6 +343,10 @@ class Discussions extends Tool {
         }
         if ( ! $this->isInstructor() ) {
             return new JsonResponse(array('success' => false, 'error' => 'Instructor required'), 403);
+        }
+        $csrf = self::requireCsrfJson();
+        if ( $csrf ) {
+            return $csrf;
         }
 
         $order = U::get($_POST, 'order', array());
@@ -562,6 +576,10 @@ class Discussions extends Tool {
             U::flashError(__('You must be logged in with a course context to mark discussions as read.'));
             return new RedirectResponse(U::addSession($discussions_url));
         }
+        $csrf = self::requireCsrf(U::addSession($discussions_url));
+        if ( $csrf ) {
+            return $csrf;
+        }
 
         if ( ! U::isNotEmpty($CFG->tdiscus) || ! $CFG->tdiscus ) {
             U::flashError(__('Discussions are not available on this site.'));
@@ -613,6 +631,10 @@ class Discussions extends Tool {
         if ( ! $this->isInstructor() ) {
             U::flashError(__('Only instructors can run discussion expiration.'));
             return new RedirectResponse($redirect_url);
+        }
+        $csrf = self::requireCsrf($redirect_url);
+        if ( $csrf ) {
+            return $csrf;
         }
 
         $months_raw = trim((string) U::get($_POST, 'months', ''));
@@ -796,6 +818,10 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
             U::flashError(__('Only instructors can run discussion expiration.'));
             return new RedirectResponse($redirect_url);
         }
+        $csrf = self::requireCsrf($redirect_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
 
         $months_raw = trim((string) U::get($_POST, 'months', ''));
         $months = intval($months_raw);
@@ -963,7 +989,7 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
         echo('<li>');
         echo('<a href="#" class="tsugi-discussions-reset-unread-tracking-link">'.__('Reset unread tracking for all users').'</a>');
         echo(' <span class="text-muted">('.__('clears read tracking for this course; subscription preferences are unchanged').')</span>');
-        echo('<form method="post" action="'.htmlspecialchars(U::addSession($this->toolHome(self::ROUTE).'/reset-unread-tracking')).'" class="tsugi-discussions-reset-unread-tracking-form" style="display:none;"></form>');
+        echo('<form method="post" action="'.htmlspecialchars(U::addSession($this->toolHome(self::ROUTE).'/reset-unread-tracking')).'" class="tsugi-discussions-reset-unread-tracking-form" style="display:none;">'.self::csrfField().'</form>');
         echo('</li>');
         */
         echo('<li><a href="'.htmlspecialchars(U::addSession($this->toolHome(self::ROUTE).'/expire-comments')).'">'.__('Expire old comments').'</a></li>');
@@ -1013,6 +1039,10 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
         if ( ! $this->isInstructor() ) {
             U::flashError(__('Only instructors can manage discussions.'));
             return new RedirectResponse($redirect_url);
+        }
+        $csrf = self::requireCsrf($redirect_url);
+        if ( $csrf ) {
+            return $csrf;
         }
         if ( ! U::isNotEmpty($CFG->tdiscus) || ! $CFG->tdiscus ) {
             U::flashError(__('Discussions are not available on this site.'));
@@ -1116,11 +1146,13 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
         echo('<pre style="max-height: 24em; overflow:auto;">'.htmlspecialchars(json_encode($snapshot, JSON_PRETTY_PRINT)).'</pre>');
 
         echo('<form method="post" action="'.htmlspecialchars($run_url).'" class="form-inline" style="margin-bottom:0.75em;">');
+        echo(self::csrfField());
         echo('<input type="hidden" name="confirm" value="0">');
         echo('<button type="submit" class="btn btn-info">'.__('Run Pre-Scan Again (dry run)').'</button>');
         echo('</form>');
 
         echo('<form method="post" action="'.htmlspecialchars($run_url).'" class="form-inline tsugi-discussions-scan-fix-form">');
+        echo(self::csrfField());
         echo('<input type="hidden" name="confirm" value="1">');
         echo('<button type="submit" class="btn btn-danger" data-running-label="'.htmlspecialchars(__('Applying repairs…')).'">'.__('Apply Repair (phase 2)').'</button>');
         echo('</form>');
@@ -1195,6 +1227,10 @@ WHERE thread_id IN (:THREAD_ID_1, :THREAD_ID_2, ... up to ".self::EXPIRE_DELETE_
         if ( ! $this->isInstructor() ) {
             U::flashError(__('Only instructors can manage discussions.'));
             return new RedirectResponse($redirect_url);
+        }
+        $csrf = self::requireCsrf($redirect_url);
+        if ( $csrf ) {
+            return $csrf;
         }
         if ( ! U::isNotEmpty($CFG->tdiscus) || ! $CFG->tdiscus ) {
             U::flashError(__('Discussions are not available on this site.'));
@@ -1514,6 +1550,7 @@ WHERE L.context_id = :CID
                     This first version is dry run only. It never deletes data, and always shows the SQL that would run.
                 </p>
                 <form method="post" action="<?= htmlspecialchars($action_url) ?>" class="form-inline" style="margin-bottom: 1em;">
+                    <?= self::csrfField() ?>
                     <div class="form-group">
                         <label for="expire-months">Months:</label>
                         <input id="expire-months" type="number" min="2" step="1" name="months"
@@ -1548,6 +1585,7 @@ Bound parameters
                     -->
                     <?php if ( intval(U::get($result, 'count', 0)) > 0 ) { ?>
                         <form method="post" action="<?= htmlspecialchars($action_url) ?>" class="form-inline tsugi-expire-delete-form">
+                            <?= self::csrfField() ?>
                             <input type="hidden" name="months" value="<?= intval($result['months']) ?>">
                             <input type="hidden" name="confirm" value="1">
                             <button type="submit" class="btn btn-danger"
@@ -1591,6 +1629,7 @@ Bound parameters
                     Deleting one match removes that comment and its whole subtree. Dry run shows counts and SQL; confirming deletes up to <?= intval(self::EXPIRE_DELETE_BATCH_LIMIT) ?> subtree(s) per run.
                 </p>
                 <form method="post" action="<?= htmlspecialchars($action_url) ?>" class="form-inline" style="margin-bottom: 1em;">
+                    <?= self::csrfField() ?>
                     <div class="form-group">
                         <label for="expire-comments-months">Months:</label>
                         <input id="expire-comments-months" type="number" min="2" step="1" name="months"
@@ -1626,6 +1665,7 @@ Bound parameters
                     -->
                     <?php if ( $tdiscus_threads_ok && intval(U::get($result, 'count', 0)) > 0 ) { ?>
                         <form method="post" action="<?= htmlspecialchars($action_url) ?>" class="form-inline tsugi-expire-delete-form">
+                            <?= self::csrfField() ?>
                             <input type="hidden" name="months" value="<?= intval($result['months']) ?>">
                             <input type="hidden" name="confirm" value="1">
                             <button type="submit" class="btn btn-danger"

--- a/lib/src/Controllers/Lessons.php
+++ b/lib/src/Controllers/Lessons.php
@@ -157,6 +157,10 @@ class Lessons extends Tool {
             return new Response(json_encode(['success' => false, 'error' => 'Not allowed']), 403, ['Content-Type' => 'application/json']);
         }
         $this->requireInstructor(U::addSession($this->toolHome(self::ROUTE)));
+        $csrf = self::requireCsrfJson();
+        if ( $csrf ) {
+            return $csrf;
+        }
 
         $action = U::get($_POST, 'action');
         if ( $action !== 'save' ) {
@@ -220,6 +224,10 @@ class Lessons extends Tool {
             return new Response('Lesson authoring is not enabled', 403);
         }
         $this->requireInstructor($author_url);
+        $csrf = self::requireCsrf($author_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
 
         if ( empty($_FILES['file']) || ! is_array($_FILES['file']) ) {
             U::flashError(__('No file uploaded.'));

--- a/lib/src/Controllers/Notifications.php
+++ b/lib/src/Controllers/Notifications.php
@@ -333,6 +333,7 @@ class Notifications extends Tool {
                     
                     fetch(url, {
                         method: 'POST',
+                        headers: tsugiCsrfHeaders(),
                         body: formData
                     })
                     .then(response => response.json())
@@ -442,7 +443,8 @@ class Notifications extends Tool {
                     var url = this.getAttribute('data-url');
                     
                     fetch(url, {
-                        method: 'POST'
+                        method: 'POST',
+                        headers: tsugiCsrfHeaders()
                     })
                     .then(response => response.json())
                     .then(data => {
@@ -661,6 +663,10 @@ class Notifications extends Tool {
         global $PDOX, $CFG;
 
         $this->requireAuth();
+        $csrf = self::requireCsrfJson();
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         LTIX::getConnection();
         
@@ -748,6 +754,10 @@ class Notifications extends Tool {
         global $PDOX, $CFG;
 
         $this->requireAuth();
+        $csrf = self::requireCsrfJson();
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         LTIX::getConnection();
         
@@ -815,6 +825,10 @@ class Notifications extends Tool {
 
         try {
             $this->requireAuth();
+            $csrf = self::requireCsrfJson();
+            if ( $csrf ) {
+                return $csrf;
+            }
             
             LTIX::getConnection();
             
@@ -948,6 +962,7 @@ class Notifications extends Tool {
                     <p class="text-muted">This will send a notification to your account. Useful for testing or reminders.</p>
                     
                     <form method="POST" action="<?= htmlspecialchars($send_url) ?>">
+                        <?= self::csrfField() ?>
                         <div class="form-group">
                             <label for="title">Title *</label>
                             <input type="text" class="form-control" id="title" name="title" 
@@ -987,13 +1002,16 @@ class Notifications extends Tool {
         global $CFG;
 
         $this->requireAuth();
+        $tool_home = $this->toolHome(self::ROUTE);
+        $send_url = $tool_home . '/send';
+        $csrf = self::requireCsrf($send_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         LTIX::getConnection();
         
         $user_id = U::loggedInUserId();
-        
-        $tool_home = $this->toolHome(self::ROUTE);
-        $send_url = $tool_home . '/send';
         $back_url = $tool_home;
         
         $title = trim(U::get($_POST, 'title'));
@@ -1092,6 +1110,7 @@ class Notifications extends Tool {
                         <p class="text-muted">Select a student and compose a notification to send to them.</p>
                         
                         <form method="POST" action="<?= htmlspecialchars($send_url) ?>">
+                            <?= self::csrfField() ?>
                             <div class="form-group">
                                 <label for="student_id">Student *</label>
                                 <select class="form-control" id="student_id" name="student_id" required>
@@ -1149,13 +1168,17 @@ class Notifications extends Tool {
 
         $this->requireInstructor('/notifications');
         
+        $tool_home = $this->toolHome(self::ROUTE);
+        $send_url = $tool_home . '/send-to-student';
+        $csrf = self::requireCsrf($send_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
+        
         LTIX::getConnection();
         
         $user_id = U::loggedInUserId();
         $context_id = U::currentContextId();
-        
-        $tool_home = $this->toolHome(self::ROUTE);
-        $send_url = $tool_home . '/send-to-student';
         $back_url = $tool_home;
         
         $student_id = U::get($_POST, 'student_id');
@@ -1273,6 +1296,10 @@ class Notifications extends Tool {
      */
     public function markRead(Request $request) {
         $this->requireAuth();
+        $csrf = self::requireCsrfJson();
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         LTIX::getConnection();
         
@@ -1297,6 +1324,10 @@ class Notifications extends Tool {
      */
     public function markAllRead(Request $request) {
         $this->requireAuth();
+        $csrf = self::requireCsrfJson();
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         LTIX::getConnection();
         

--- a/lib/src/Controllers/Pages.php
+++ b/lib/src/Controllers/Pages.php
@@ -397,6 +397,7 @@ class Pages extends Tool {
             <h1>Add New Page</h1>
             
             <form method="post" id="page_form">
+                <?= self::csrfField() ?>
                 <div class="form-group">
                     <label for="title">Title:</label>
                     <input type="text" class="form-control" id="title" name="title" 
@@ -480,6 +481,10 @@ class Pages extends Tool {
         $tool_home = $this->toolHome(self::ROUTE);
         $add_url = $tool_home . '/add';
         $manage_url = $tool_home . '/manage';
+        $csrf = self::requireCsrf($add_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         LTIX::getConnection();
         
@@ -615,6 +620,7 @@ class Pages extends Tool {
             <h1>Edit Page</h1>
 
             <form method="post" id="page_form">
+                <?= self::csrfField() ?>
                 <div class="form-group">
                     <label for="title">Title:</label>
                     <input type="text" class="form-control" id="title" name="title" 
@@ -698,6 +704,10 @@ class Pages extends Tool {
         
         $tool_home = $this->toolHome(self::ROUTE);
         $manage_url = $tool_home . '/manage';
+        $csrf = self::requireCsrf($manage_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         LTIX::getConnection();
         
@@ -910,6 +920,7 @@ class Pages extends Tool {
                                     <a href="<?= htmlspecialchars($history_url) ?>" class="btn btn-xs btn-info" aria-label="<?= htmlspecialchars(__('History')) ?> <?= htmlspecialchars($page['title']) ?>">History</a>
                                     <?php endif; ?>
                                     <form method="post" style="display: inline;" onsubmit="return confirm('Are you sure you want to toggle the published status?');">
+                                        <?= self::csrfField() ?>
                                         <input type="hidden" name="action" value="toggle_published">
                                         <input type="hidden" name="page_id" value="<?= $page['page_id'] ?>">
                                         <button type="submit" class="btn btn-xs btn-warning" aria-label="<?= $page['published'] ? 'Unpublish' : 'Publish' ?> <?= htmlspecialchars($page['title']) ?>">
@@ -917,6 +928,7 @@ class Pages extends Tool {
                                         </button>
                                     </form>
                                     <form method="post" style="display: inline;" onsubmit="return confirm('Are you sure you want to delete this page?');">
+                                        <?= self::csrfField() ?>
                                         <input type="hidden" name="action" value="delete">
                                         <input type="hidden" name="page_id" value="<?= $page['page_id'] ?>">
                                         <button type="submit" class="btn btn-xs btn-danger" aria-label="Delete <?= htmlspecialchars($page['title']) ?>">Delete</button>
@@ -940,6 +952,10 @@ class Pages extends Tool {
         
         $tool_home = $this->toolHome(self::ROUTE);
         $manage_url = $tool_home . '/manage';
+        $csrf = self::requireCsrf($manage_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
         
         LTIX::getConnection();
         
@@ -1067,11 +1083,9 @@ class Pages extends Tool {
                                         data-body="<?= htmlspecialchars($h['body']) ?>">View / Diff</button>
                                 <form method="post" action="<?= $tool_home ?>/history/restore" style="display: inline;"
                                       onsubmit="return confirm('Restore this version? The current version will be saved to history.');">
+                                    <?= self::csrfField() ?>
                                     <input type="hidden" name="page_id" value="<?= $page_id ?>">
                                     <input type="hidden" name="history_id" value="<?= (int)$h['history_id'] ?>">
-                                    <?php if (!empty($_SESSION['CSRF_TOKEN'])): ?>
-                                    <input type="hidden" name="CSRF_TOKEN" value="<?= htmlspecialchars($_SESSION['CSRF_TOKEN']) ?>">
-                                    <?php endif; ?>
                                     <button type="submit" class="btn btn-xs btn-primary">Restore</button>
                                 </form>
                             </td>
@@ -1164,6 +1178,10 @@ class Pages extends Tool {
 
         $tool_home = $this->toolHome(self::ROUTE);
         $manage_url = $tool_home . '/manage';
+        $csrf = self::requireCsrf($manage_url);
+        if ( $csrf ) {
+            return $csrf;
+        }
 
         LTIX::getConnection();
 

--- a/lib/src/Controllers/Profile.php
+++ b/lib/src/Controllers/Profile.php
@@ -126,6 +126,7 @@ echo(' ('.htmlentities($_SESSION['email']).")</h1>\n");
         ?>
 
         <form method="POST">
+            <?= \Tsugi\Controllers\Tool::csrfField() ?>
             <div style="display: flex; justify-content: space-between;">
                 <fieldset class="control-group">
                     <legend>Would you like to set a theme override?</legend>
@@ -249,6 +250,10 @@ Send me notification mail for important things like my assignment was graded.
 
         if ( ! isset($_SESSION['profile_id']) ) {
             return new RedirectResponse($home);
+        }
+        $csrf = Tool::requireCsrf($home);
+        if ( $csrf ) {
+            return $csrf;
         }
 
         $stmt = $PDOX->queryDie(

--- a/lib/src/Controllers/Stripe.php
+++ b/lib/src/Controllers/Stripe.php
@@ -94,6 +94,7 @@ You will receive <?= htmlspecialchars($premium_period) ?> of <?= htmlspecialchar
 <p><em><?= htmlspecialchars($refund_policy) ?></em></p>
 <?php } ?>
 <form method="post" action="">
+<?= Tool::csrfField() ?>
 <p>
 <button type="submit" class="btn btn-success">Continue to payment</button>
 <a href="<?= htmlspecialchars($profile_url) ?>" class="btn btn-default">Cancel</a>
@@ -122,6 +123,10 @@ You will receive <?= htmlspecialchars($premium_period) ?> of <?= htmlspecialchar
         if ($user_id <= 0) {
             Login::setReturnUrl($checkout_url);
             return new RedirectResponse(Login::loginUrl());
+        }
+        $csrf = Tool::requireCsrf($checkout_url);
+        if ( $csrf ) {
+            return $csrf;
         }
 
         $cfg = StripeUtil::config();

--- a/lib/src/Controllers/Tool.php
+++ b/lib/src/Controllers/Tool.php
@@ -117,9 +117,12 @@ abstract class Tool {
             if ( ! is_array($parts) || empty($parts['host']) ) {
                 continue;
             }
-            $expected = ($parts['scheme'] ?? 'http').'://'.$parts['host'];
-            if ( ! empty($parts['port']) ) {
-                $expected .= ':'.$parts['port'];
+            $scheme = $parts['scheme'] ?? 'http';
+            $expected = $scheme.'://'.$parts['host'];
+            $port = isset($parts['port']) ? (int) $parts['port'] : 0;
+            $default_port = ($scheme === 'https') ? 443 : 80;
+            if ( $port > 0 && $port !== $default_port ) {
+                $expected .= ':'.$port;
             }
             if ( hash_equals($expected, $origin) ) {
                 return true;

--- a/lib/src/Controllers/Tool.php
+++ b/lib/src/Controllers/Tool.php
@@ -10,6 +10,7 @@ use Tsugi\Core\Membership;
 use Tsugi\Grades\GradeUtil;
 use Tsugi\Lumen\Application;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * Base class for LMS tool controllers
@@ -110,6 +111,42 @@ abstract class Tool {
             return null;
         }
         return new RedirectResponse($redirect);
+    }
+
+    /**
+     * For classic PHP tools that redirect with header('Location').
+     *
+     * @param string $url Already session-bearing Location target.
+     * @return bool True when the caller should return (token was bad).
+     */
+    public static function csrfRedirect($url) {
+        if ( self::csrfOk() ) {
+            return false;
+        }
+        U::flashError('Missing or invalid CSRF token');
+        header('Location: '.$url);
+        return true;
+    }
+
+    /**
+     * JSON 403 when the CSRF token is missing or invalid (no flash).
+     *
+     * @param array|null $payload
+     * @return JsonResponse|null Null when the token is valid.
+     */
+    public static function requireCsrfJson($payload = null) {
+        if ( self::csrfOk() ) {
+            return null;
+        }
+        if ( $payload === null ) {
+            $payload = array(
+                'success' => false,
+                'status' => 'error',
+                'error' => 'Missing or invalid CSRF token',
+                'detail' => 'Missing or invalid CSRF token',
+            );
+        }
+        return new JsonResponse($payload, 403);
     }
 
     /**

--- a/lib/src/Controllers/Tool.php
+++ b/lib/src/Controllers/Tool.php
@@ -70,21 +70,62 @@ abstract class Tool {
     }
 
     /**
-     * True when POST CSRF_TOKEN (or X-CSRF-TOKEN) matches the session token.
+     * True when POST CSRF_TOKEN (or X-CSRF-TOKEN) matches the session token,
+     * or the browser marks this POST as same-origin.
+     *
+     * Cookie-session pages (admin unlock) can lose the GET session cookie on the
+     * following POST; Chrome still sends Sec-Fetch-Site/Origin, which is enough
+     * to reject cross-site CSRF. LTI launches must not use this helper.
      *
      * @return bool
      */
     public static function csrfOk() {
         $token = $_SESSION['CSRF_TOKEN'] ?? '';
-        if ( ! is_string($token) || $token === '' ) {
-            return false;
+        if ( is_string($token) && $token !== '' ) {
+            $posted = U::get($_POST, 'CSRF_TOKEN', '');
+            if ( is_string($posted) && $posted !== '' && hash_equals($token, $posted) ) {
+                return true;
+            }
+            $header = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? $_SERVER['HTTP_X_CSRFTOKEN'] ?? '';
+            if ( is_string($header) && $header !== '' && hash_equals($token, $header) ) {
+                return true;
+            }
         }
-        $posted = U::get($_POST, 'CSRF_TOKEN', '');
-        if ( is_string($posted) && $posted !== '' && hash_equals($token, $posted) ) {
+        return self::sameOriginPost();
+    }
+
+    /**
+     * True when this request is a same-origin navigation (not a cross-site CSRF POST).
+     *
+     * @return bool
+     */
+    public static function sameOriginPost() {
+        global $CFG;
+        $site = $_SERVER['HTTP_SEC_FETCH_SITE'] ?? '';
+        if ( is_string($site) && $site === 'same-origin' ) {
             return true;
         }
-        $header = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? $_SERVER['HTTP_X_CSRFTOKEN'] ?? '';
-        return is_string($header) && $header !== '' && hash_equals($token, $header);
+        $origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+        if ( ! is_string($origin) || $origin === '' ) {
+            return false;
+        }
+        foreach ( array($CFG->wwwroot ?? '', $CFG->apphome ?? '') as $base ) {
+            if ( ! is_string($base) || $base === '' ) {
+                continue;
+            }
+            $parts = parse_url($base);
+            if ( ! is_array($parts) || empty($parts['host']) ) {
+                continue;
+            }
+            $expected = ($parts['scheme'] ?? 'http').'://'.$parts['host'];
+            if ( ! empty($parts['port']) ) {
+                $expected .= ':'.$parts['port'];
+            }
+            if ( hash_equals($expected, $origin) ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/lib/src/Controllers/static/Announcements/dismiss.js
+++ b/lib/src/Controllers/static/Announcements/dismiss.js
@@ -143,6 +143,7 @@ var dismissToggle = (function() {
         
         fetch(dismissUrl, {
             method: 'POST',
+            headers: tsugiCsrfHeaders(),
             body: formData
         })
         .then(function(response) {

--- a/lib/src/Controllers/static/Announcements/tsugi-announce.js
+++ b/lib/src/Controllers/static/Announcements/tsugi-announce.js
@@ -283,6 +283,7 @@ class TsugiAnnounce extends LitElement {
         try {
             const response = await fetch(this.dismissUrl, {
                 method: 'POST',
+                headers: tsugiCsrfHeaders(),
                 body: formData
             });
             const data = await response.json();

--- a/lib/src/Controllers/static/Notifications/notifications.js
+++ b/lib/src/Controllers/static/Notifications/notifications.js
@@ -42,9 +42,9 @@ async function subscribeToNotifications() {
         const subscribeUrl = subscribeBtn.getAttribute('data-url');
         const subResponse = await fetch(subscribeUrl, {
             method: 'POST',
-            headers: {
+            headers: tsugiCsrfHeaders({
                 'Content-Type': 'application/json',
-            },
+            }),
             body: JSON.stringify(subscription.toJSON())
         });
 
@@ -70,9 +70,9 @@ async function unsubscribeFromNotifications() {
         
         const response = await fetch(unsubscribeUrl, {
             method: 'POST',
-            headers: {
+            headers: tsugiCsrfHeaders({
                 'Content-Type': 'application/json',
-            }
+            })
         });
 
         const result = await response.json();
@@ -105,9 +105,9 @@ async function sendTestNotification() {
         
         const response = await fetch(testUrl, {
             method: 'POST',
-            headers: {
+            headers: tsugiCsrfHeaders({
                 'Content-Type': 'application/json',
-            }
+            })
         });
 
         // Check if response is OK and content-type is JSON

--- a/lib/src/Controllers/templates/Lessons/author_interface.inc.php
+++ b/lib/src/Controllers/templates/Lessons/author_interface.inc.php
@@ -1674,6 +1674,7 @@ function saveChanges() {
     $.ajax({
         url: window.location.pathname,
         method: 'POST',
+        headers: tsugiCsrfHeaders(),
         data: {
             action: 'save',
             data: jsonData

--- a/lib/src/UI/CrudForm.php
+++ b/lib/src/UI/CrudForm.php
@@ -57,6 +57,7 @@ class CrudForm {
      */
     public static function insertForm($fields, $from_location, $titles=false, $fields_defaults=false) {
         echo('<form method="post" autocomplete="off">'."\n");
+        echo(\Tsugi\Controllers\Tool::csrfField()."\n");
 
         for($i=0; $i < count($fields); $i++ ) {
             $field = $fields[$i];
@@ -97,6 +98,9 @@ class CrudForm {
     public static function handleInsert($tablename, $fields) {
         global $PDOX;
         if ( isset($_POST['doSave']) && count($_POST) > 0 ) {
+            if ( ! \Tsugi\Controllers\Tool::checkCsrf() ) {
+                return self::CRUD_FAIL;
+            }
             $names = '';
             $values = '';
             $parms = array();
@@ -192,6 +196,7 @@ class CrudForm {
         $do_edit = isset($_REQUEST['edit']) && $_REQUEST['edit'] == 'yes';
 
         echo('<form method="post" autocomplete="off">'."\n");
+        echo(\Tsugi\Controllers\Tool::csrfField()."\n");
         if ( is_string($from_location) ) echo('<a href="'.$from_location.'" class="btn btn-default">'._m('Exit').'</a>'."\n");
         if ( $allow_edit ) {
             if ( $do_edit ) {
@@ -338,6 +343,13 @@ class CrudForm {
         }
 
         // We know we are OK because we already retrieved the row
+        if ( ( $allow_delete && isset($_POST['doDelete']) ) ||
+             ( $allow_edit && $do_edit && isset($_POST['doUpdate']) ) ) {
+            if ( ! \Tsugi\Controllers\Tool::checkCsrf() ) {
+                return self::CRUD_FAIL;
+            }
+        }
+
         if ( $allow_delete && isset($_POST['doDelete']) ) {
             $sql = "DELETE FROM $tablename WHERE $where_clause";
             $stmt = $PDOX->queryDie($sql, $query_parms);

--- a/lib/src/UI/Lessons.php
+++ b/lib/src/UI/Lessons.php
@@ -2541,6 +2541,7 @@ class Lessons {
             }
             echo('<div style="margin: 1em 0 0; display: flex; gap: 0.5em; flex-wrap: wrap;">');
             echo('<form method="post" action="'.htmlspecialchars($mark_read_url).'" class="tsugi-discussions-mark-read-form" style="margin: 0;">');
+            echo(\Tsugi\Controllers\Tool::csrfField());
             echo('<button type="submit" class="btn btn-default btn-sm">'.htmlentities(__('Mark all as read')).'</button>');
             echo('</form>'."\n");
             if ( $show_expire_button ) {

--- a/lib/src/UI/Output.php
+++ b/lib/src/UI/Output.php
@@ -137,11 +137,9 @@ class Output {
         echo(self::headerStart());
         echo($this->headerData());
         echo(self::headerCss());
-        if ( ($_SESSION['CSRF_TOKEN'] ?? null) ) {
-            echo('<script type="text/javascript">CSRF_TOKEN = "'.($_SESSION['CSRF_TOKEN'] ?? '').'";</script>'."\n");
-        } else {
-            echo('<script type="text/javascript">CSRF_TOKEN = "TODORemoveThis";</script>'."\n");
-        }
+        $csrf = LTIX::ensureCsrfToken();
+        echo('<script type="text/javascript">CSRF_TOKEN = "'.htmlspecialchars($csrf, ENT_QUOTES).'";'
+            .'function tsugiCsrfHeaders(h){h=h||{};if(CSRF_TOKEN){h["X-CSRF-TOKEN"]=CSRF_TOKEN;}return h;}</script>'."\n");
 
         // Set the containing frame id if we have one
         $element_id = LTIX::ltiRawParameter('ext_lti_element_id', false);

--- a/lib/src/UI/SettingsDialog.php
+++ b/lib/src/UI/SettingsDialog.php
@@ -92,9 +92,13 @@ class SettingsDialog {
 
         if ( isset($_POST['settings_internal_post']) && $this->instructor() ) {
             $newsettings = array();
+            if ( ! \Tsugi\Controllers\Tool::checkCsrf() ) {
+                return true;
+            }
             foreach ( $_POST as $k => $v ) {
                 if ( $k == session_name() ) continue;
                 if ( $k == 'settings_internal_post' ) continue;
+                if ( $k == 'CSRF_TOKEN' ) continue;
                 if ( strpos('_ignore',$k) > 0 ) continue;
                 $newsettings[$k] = $v;
             }
@@ -185,6 +189,7 @@ class SettingsDialog {
             <span id="save_fail" class="text-danger" style="display:none;"><?php _me('Unable to save settings'); ?></span>
             <?php if ( $this->instructor() ) { ?>
             <input type="hidden" name="settings_internal_post" value="1"/>
+            <?= \Tsugi\Controllers\Tool::csrfField() ?>
             <?php }
     }
 

--- a/lib/src/UI/SettingsForm.php
+++ b/lib/src/UI/SettingsForm.php
@@ -50,9 +50,13 @@ class SettingsForm {
 
         if ( isset($_POST['settings_internal_post']) && $USER->instructor ) {
             $newsettings = array();
+            if ( ! \Tsugi\Controllers\Tool::checkCsrf() ) {
+                return true;
+            }
             foreach ( $_POST as $k => $v ) {
                 if ( $k == session_name() ) continue;
                 if ( $k == 'settings_internal_post' ) continue;
+                if ( $k == 'CSRF_TOKEN' ) continue;
                 if ( strpos('_ignore',$k) > 0 ) continue;
                 if ( strpos('.ignore',$k) > 0 ) continue;
                 $newsettings[$k] = $v;
@@ -147,6 +151,7 @@ class SettingsForm {
             <span id="tsugi_settings_save_fail" class="text-danger" style="display:none;"><?php _me('Unable to save settings'); ?></span>
             <?php if ( $USER->instructor ) { ?>
             <input type="hidden" name="settings_internal_post" value="1"/>
+            <?= \Tsugi\Controllers\Tool::csrfField() ?>
             <?php }
     }
 
@@ -169,6 +174,7 @@ class SettingsForm {
                 if (n.name.length < 1) return;
                 if (n.name.endsWith('.ignore') ) return;
                 if (n.name == 'settings_internal_post' ) return;
+                if (n.name == 'CSRF_TOKEN' ) return;
                 json[n.name] = $(n).val();
                 return;
             });
@@ -178,6 +184,7 @@ class SettingsForm {
                 url: '<?= U::addSession($CFG->wwwroot."/api/settings.php") ?>',
                 dataType: 'json',
                 contentType: 'application/json',
+                headers: tsugiCsrfHeaders(),
                 data: JSON.stringify(json),
                 success: function (data) {
                     $('#tsugi_settings_dialog').modal('hide');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -28,8 +28,6 @@ parameters:
         - store
         - util
         - index.php
-        - login.php
-        - logout.php
         - top.php
         - tsugi.php
         - about.php

--- a/qa/tests/AdminTest.php
+++ b/qa/tests/AdminTest.php
@@ -18,7 +18,9 @@ final class AdminTest extends TsugiPantherTestCase
         $driver = $client->getWebDriver();
         $input = $driver->findElement(WebDriverBy::name('passphrase'));
         $input->sendKeys($passphrase);
-        $input->submit();
+        // Native form.submit() includes the CSRF hidden field; WebDriver element
+        // submit() on the password input can omit it and fail closed.
+        $driver->executeScript('document.querySelector("form[method=\'post\']").submit();');
 
         $deadline = microtime(true) + 5;
         while (microtime(true) < $deadline) {

--- a/qa/tests/AdminTest.php
+++ b/qa/tests/AdminTest.php
@@ -18,21 +18,22 @@ final class AdminTest extends TsugiPantherTestCase
         $driver = $client->getWebDriver();
         $input = $driver->findElement(WebDriverBy::name('passphrase'));
         $input->sendKeys($passphrase);
-        // Native form.submit() includes the CSRF hidden field; WebDriver element
-        // submit() on the password input can omit it and fail closed.
-        $driver->executeScript('document.querySelector("form[method=\'post\']").submit();');
+        $driver->findElement(WebDriverBy::cssSelector('form[method="post"] input[type="submit"]'))->click();
 
-        $deadline = microtime(true) + 5;
+        $deadline = microtime(true) + 15;
+        $page = '';
         while (microtime(true) < $deadline) {
-            if (str_contains($client->getPageSource(), 'Administration Console')) {
+            $page = $client->getPageSource();
+            if (str_contains($page, 'Administration Console')) {
                 break;
             }
             usleep(200000);
         }
 
+        $this->assertStringNotContainsString('Missing or invalid CSRF token', $page);
         $this->assertStringContainsString(
             'Administration Console',
-            $client->getPageSource()
+            $page
         );
 
         $this->captureScreenshot($client, 'admin-console');

--- a/qa/tests/ToolHappyPathTest.php
+++ b/qa/tests/ToolHappyPathTest.php
@@ -118,6 +118,8 @@ final class ToolHappyPathTest extends ToolLaunchHarness
             $driver->executeScript(
                 'var tokenEl = document.querySelector("input[name=\"_LTI_TSUGI\"]");
                  var token = tokenEl ? tokenEl.value : "";
+                 var csrfEl = document.querySelector("input[name=\"CSRF_TOKEN\"]");
+                 var csrf = csrfEl ? csrfEl.value : (window.CSRF_TOKEN || "");
                  var form = document.createElement("form");
                  form.method = "post";
                  form.action = window.location.pathname + window.location.search;
@@ -129,6 +131,7 @@ final class ToolHappyPathTest extends ToolLaunchHarness
                     form.appendChild(input);
                  }
                  add("_LTI_TSUGI", token);
+                 add("CSRF_TOKEN", csrf);
                  add("title", arguments[0]);
                  add("body", arguments[1]);
                  document.body.appendChild(form);

--- a/tool/gift/configure.php
+++ b/tool/gift/configure.php
@@ -26,6 +26,9 @@ $results_rows = $PDOX->allRowsDie("SELECT result_id, R.link_id AS link_id, R.use
             array(':LI'=>$LINK->id, ':CI'=>$CONTEXT->id));
 
 if (!empty($_POST)) {
+  if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('configure.php')) ) {
+      return;
+  }
 
   $gift = parse_configure_post();
 
@@ -62,6 +65,7 @@ $OUTPUT->topNav($menu);
 $OUTPUT->flashMessages();
 ?>
 <form method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <?php
 // If we found results rows that weren't empty earlier, show a warning and disable the entire form
 if ($results_rows) {

--- a/tool/gift/convert.php
+++ b/tool/gift/convert.php
@@ -122,6 +122,7 @@ The sample text below has some GIFT formats that this tool does not yet support 
 below will not be converted.  Feel free to send me a Pull request on gitHub :).
 </p>
 <form method="post" action="process.php" target="working" style="margin:20px;">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p style="float:right">
 <input type="submit" name="submit" class="btn btn-primary" value="Convert GIFT to QTI"
 onclick="$('#myModal').modal('show');"></p>

--- a/tool/gift/convert.php
+++ b/tool/gift/convert.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once "../config.php";
 require_once "util.php";
 session_start();
 header('Content-Type: text/html; charset=utf-8');

--- a/tool/gift/export.php
+++ b/tool/gift/export.php
@@ -34,6 +34,7 @@ This is an experimental feature to convert your quiz to
 </p>
 </p>
 <form method="post" action="<?= addSession('process.php') ?>" target="working" style="margin:20px;">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p style="float:right">
 <p>Quiz Title: <input type="text" name="title" size="60" value="<?= $LAUNCH->link->title ?>"/></p>
 <p>Quiz File Name (no suffix): <input type="text" name="name" size="30" value="<?= $fname ?>"/> (optional)</p>

--- a/tool/gift/index.php
+++ b/tool/gift/index.php
@@ -17,6 +17,9 @@ $LAUNCH = LTIX::requireData();
 $p = $CFG->dbprefix;
 
 if ( SettingsForm::isSettingsPost() ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('index.php')) ) {
+        return;
+    }
     // Validate settings...
     if ( isset($_POST['tries']) && $_POST['tries'] != '' && ! is_numeric($_POST['tries']) ) {
         $_SESSION['error'] = __('Tries must be numeric');
@@ -43,6 +46,9 @@ $LAUNCH->link->settingsDefaultsFromCustom(array('tries', 'delay', 'title', 'inst
 
 $password = Settings::linkGet('password');
 if ( strlen(U::get($_POST, "password", '')) > 0  ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('index.php')) ) {
+        return;
+    }
     $_SESSION['assignment_password'] = U::get($_POST, "password");
     header( 'Location: '.addSession('index.php') ) ;
     return;
@@ -94,6 +100,9 @@ if ( $RESULT->atAttemptLimit($max_tries, $attempts) ) {
 
 $oldgrade = $RESULT->grade;
 if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('index.php')) ) {
+        return;
+    }
     if ( $questions == false ) {
         $_SESSION['error'] ='Internal error: No questions';
         header( 'Location: '.addSession('index.php') ) ;
@@ -204,6 +213,7 @@ unlock this assignment.
 </p>
 <p>
 <form method="post">
+    <?= \Tsugi\Controllers\Tool::csrfField() ?>
     <label for="quiz_password">Password:</label>
     <input type="password" name="password" id="quiz_password">
     <input type="submit" value="<?= htmlspecialchars(__('Submit')) ?>">
@@ -268,6 +278,7 @@ parse_gift($gift, $questions, $errors);
 
 ?>
 <form method="post" aria-label="Quiz questions">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <ol id="quiz" role="list">
 </ol>
 <?php

--- a/tool/gift/old_configure.php
+++ b/tool/gift/old_configure.php
@@ -17,6 +17,9 @@ $p = $CFG->dbprefix;
 
 // If they pressed Submit on the quiz content
 if ( isset($_POST['gift']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('old_configure.php')) ) {
+        return;
+    }
     $gift = $_POST['gift'];
     $_SESSION['gift'] = $gift;
 
@@ -54,6 +57,9 @@ $default = isset($_SESSION['default_quiz']) ? $_SESSION['default_quiz'] : false;
 
 // Load up the selected file
 if ( $files && isset($_POST['file']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('old_configure.php')) ) {
+        return;
+    }
     $key = isset($_POST['lock']) ? $_POST['lock'] : false;
     if ( $lock && $lock != $key ) {
         $_SESSION['error'] = 'Incorrect password';
@@ -114,6 +120,7 @@ $OUTPUT->flashMessages();
 <?php 
 if ( $files !== false ) {
 echo("<form method=\"post\">\n");
+echo(\Tsugi\Controllers\Tool::csrfField());
 // echo('<select name="file" onchange="console.dir(this); if(this.value!=0) this.form.submit();">'."\n");
 echo('<select name="file">'."\n");
 echo('<option value="0">Select Quiz</option>'."\n");
@@ -138,6 +145,7 @@ The documentation for the GIFT format comes from
 <a href="https://docs.moodle.org/29/en/GIFT_format" target="_blank">Moodle Documentation</a>.
 </p>
 <form method="post" style="margin-left:5%;">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>
 <input type="submit" class="btn btn-primary" value="Save">
 </p>

--- a/tool/gift/process.php
+++ b/tool/gift/process.php
@@ -12,6 +12,7 @@ unset($_SESSION['title']);
 unset($_SESSION['name']);
 unset($_SESSION['novalidate']);
 unset($_SESSION['htmlhack']);
+if ( ! \Tsugi\Controllers\Tool::csrfOk() ) die('Missing or invalid CSRF token');
 if ( !isset($_POST['text']) ) die('Missing input data');
 $text =  $_POST['text'];
 if ( isset($_POST['title']) ) $_SESSION['title'] = $_POST['title'];

--- a/tool/gift/process.php
+++ b/tool/gift/process.php
@@ -7,12 +7,12 @@ require_once "../config.php";
 require_once "util.php";
 
 session_start();
+if ( ! \Tsugi\Controllers\Tool::csrfOk() ) die('Missing or invalid CSRF token');
 unset($_SESSION['quiz']);
 unset($_SESSION['title']);
 unset($_SESSION['name']);
 unset($_SESSION['novalidate']);
 unset($_SESSION['htmlhack']);
-if ( ! \Tsugi\Controllers\Tool::csrfOk() ) die('Missing or invalid CSRF token');
 if ( !isset($_POST['text']) ) die('Missing input data');
 $text =  $_POST['text'];
 if ( isset($_POST['title']) ) $_SESSION['title'] = $_POST['title'];

--- a/tool/peer-grade/access.php
+++ b/tool/peer-grade/access.php
@@ -42,6 +42,12 @@ if ( $assn_id ) {
     }
 }
 
+if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('access.php')) ) {
+        return;
+    }
+}
+
 if ( isset($_POST['screen_reader']) && $submit_json ) {
     $submit_json->peer_exempt = 'yes';
 
@@ -101,6 +107,7 @@ to this screen for further instructions.
 If you cannot grade images from other students because you use a screen reader or other assistive device,
 check the box below and we will exempt you from doing peer grading for this assignment.
 <form method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <input type="checkbox" name="screen_reader" value="yes">I use a screen reader and cannot grade my peer's images<br>
 <input type="submit" value="Submit">
 <input type=submit name=doCancel onclick="location='<?php echo(addSession('index.php'));?>'; return false;" value="Go back"></p>

--- a/tool/peer-grade/configure.php
+++ b/tool/peer-grade/configure.php
@@ -16,6 +16,9 @@ $p = $CFG->dbprefix;
 
 //set json
 if ( isset($_POST['save_settings']) ) {
+  if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('configure.php')) ) {
+      return;
+  }
   $partsArray = array();
   for ($i=0; $i < 20; $i++){
     $partList = array();
@@ -178,6 +181,7 @@ function input_radio($jsonObj, $field, $value, $onclick=false) {
 ?>
 
 <form method="post">
+    <?= \Tsugi\Controllers\Tool::csrfField() ?>
     <p>
       <span data-toggle="tooltip" title="
 Description of assignment shown to students.  This can be edited

--- a/tool/peer-grade/debug.php
+++ b/tool/peer-grade/debug.php
@@ -8,6 +8,9 @@ use \Tsugi\Core\LTIX;
 $LAUNCH = LTIX::requireData();
 if ( ! $USER->instructor ) die("Instructor only");
 if ( isset($_POST['doClear']) ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('debug.php')) ) {
+        return;
+    }
     session_unset();
     die('session unset');
 }
@@ -25,6 +28,7 @@ $OUTPUT->togglePre("Session data",$OUTPUT->safe_var_dump($_SESSION));
 
 ?>
 <form method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <input type="submit" name="doClear" value="Clear Session (will log out out)">
 </form>
 <?php

--- a/tool/peer-grade/grade.php
+++ b/tool/peer-grade/grade.php
@@ -24,6 +24,12 @@ if ( isset($_GET['user_id']) ) {
     $url_stay = 'grade?user_id='.$user_id;
 }
 
+if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession($url_stay)) ) {
+        return;
+    }
+}
+
 // Model
 $row = loadAssignment();
 $assn_json = null;
@@ -217,6 +223,7 @@ showSubmission($assn_json, $submit_json, $assn_id, $user_id);
 echo('<p>'.htmlentities($assn_json->grading)."</p>\n");
 ?>
 <form method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <input type="hidden" value="<?php echo($submit_id); ?>" name="submit_id">
 <input type="hidden" value="<?php echo($user_id); ?>" name="user_id">
 <?php if ( $assn_json->peerpoints > 0 ) { ?>
@@ -236,6 +243,7 @@ echo('<p>'.htmlentities($assn_json->grading)."</p>\n");
 </form>
 <?php   if ( $assn_json->flag ) { ?>
 <form method="post" id="flagform" style="display:none">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>Please be considerate when flagging an item.  Only use
 flagging when instructor attention is needed.</p>
 <input type="hidden" value="<?php echo($submit_id); ?>" name="submit_id">

--- a/tool/peer-grade/index.php
+++ b/tool/peer-grade/index.php
@@ -20,6 +20,12 @@ if ( SettingsForm::handleSettingsPost() ) {
     return;
 }
 
+if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('index')) ) {
+        return;
+    }
+}
+
 // Grab the due date information
 $dueDate = SettingsForm::getDueDate();
 
@@ -387,6 +393,7 @@ if ( $submit_row == false ) {
     echo("<p><b>Please Upload Your Submission:</b></p>\n");
     echo('<form name="myform" enctype="multipart/form-data" method="post" action="'.
          addSession('index').'">');
+    echo(\Tsugi\Controllers\Tool::csrfField());
 
     $partno = 0;
     $content_items = array();
@@ -930,6 +937,7 @@ if ( $assn_json->maxassess < 1 ) {
 
 if ( isset($assn_json->resubmit) && $assn_json->resubmit == 'always' && $dueDate->dayspastdue <= 0 ) {
     echo('<p><form method = "post">
+        '.\Tsugi\Controllers\Tool::csrfField().'
         <input type="submit" name="deleteSubmit" value="Delete Your Submission" class="btn btn-danger"
             onclick="return confirm(\'Are you sure you want to delete your submission?\');">
         </form></p>
@@ -939,6 +947,7 @@ if ( isset($assn_json->resubmit) && $assn_json->resubmit == 'always' && $dueDate
 $OUTPUT->exitButton();
 ?>
 <form method="post" id="flagform" style="display:none">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>&nbsp;</p>
 <p>Please be considerate when flagging an item.  It does not mean
 that something is inappropriate - it simply brings the item to the

--- a/tool/peer-grade/maint.php
+++ b/tool/peer-grade/maint.php
@@ -25,6 +25,12 @@ if ( $assn === false ) {
     $assn_id = $assn['assn_id'];
 }
 
+if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('maint.php')) ) {
+        return;
+    }
+}
+
 if ( isset($_POST['restartReGrade']) ) {
     $lstmt = $PDOX->queryDie(
         "UPDATE {$p}peer_submit SET regrade=NULL
@@ -154,12 +160,15 @@ $iframeurl = addSession($CFG->getCurrentUrl().'?link_id=' . $link_id);
 
 <div>
 <form style="display: inline" method="post">
+  <?= \Tsugi\Controllers\Tool::csrfField() ?>
   <button name="catchupInstructor" class="btn btn-warning">Catch Up Instructor Points</button>
 </form>
 <form style="display: inline" method="post">
+  <?= \Tsugi\Controllers\Tool::csrfField() ?>
   <button name="restartReGrade" class="btn btn-warning">Restart Re-Grade</button>
 </form>
 <form style="display: inline" method="post" target="my_iframe" action="<?php echo($iframeurl); ?>">
+  <?= \Tsugi\Controllers\Tool::csrfField() ?>
   <button name="reGradePeer" onclick="showFrame();" class="btn btn-warning">Re-Compute Peer Grades</button>
 </form>
 <p>These are maintenance tools make sure you know how to use them.

--- a/tool/peer-grade/rate.php
+++ b/tool/peer-grade/rate.php
@@ -14,6 +14,13 @@ use \Tsugi\Grades\GradeUtil;
 $LAUNCH = LTIX::requireData();
 $p = $CFG->dbprefix;
 
+if ( count($_POST) > 0 ) {
+    $back = isset($_REQUEST['user_id']) ? 'rate.php?user_id='.$_REQUEST['user_id'] : 'index';
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession($back)) ) {
+        return;
+    }
+}
+
 if ( !isset($_REQUEST['user_id']) ) {
     die('user_id required');
 }
@@ -184,6 +191,7 @@ showSubmission($assn_json, $submit_json, $assn_id, $user_id);
 echo('<p>'.htmlentities($assn_json->grading)."</p>\n");
 ?>
 <form method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <input type="hidden" value="<?php echo($submit_id); ?>" name="submit_id">
 <input type="hidden" value="<?php echo($user_id); ?>" name="user_id">
 <?php if ( $assn_json->rating > 0 ) { ?>
@@ -202,6 +210,7 @@ value="<?= ($previous_rating > 0 ? $previous_rating : '') ?>" >
 </form>
 <?php   if ( $assn_json->flag ) { ?>
 <form method="post" id="flagform" style="display:none">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>Please be considerate when flagging an item.  Only use
 flagging when instructor attention is needed.</p>
 <input type="hidden" value="<?php echo($submit_id); ?>" name="submit_id">

--- a/tool/peer-grade/student.php
+++ b/tool/peer-grade/student.php
@@ -27,6 +27,12 @@ $p = $CFG->dbprefix;
 if ( !isset($_REQUEST['user_id']) ) die("user_id parameter required");
 $user_id = $_REQUEST['user_id'];
 
+if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession('student.php?user_id='.$user_id)) ) {
+        return;
+    }
+}
+
 // Load the assignment
 $row = loadAssignment();
 $assn_json = null;
@@ -370,6 +376,7 @@ if ( $submit_row === false ) {
 }
 
 echo('<form method="post">
+      '.\Tsugi\Controllers\Tool::csrfField().'
       <input type="hidden" name="user_id" value="'.$user_id.'">');
 
 if ( $next_user_id_ungraded !== false ) {
@@ -407,6 +414,7 @@ if ( $assn_json->rating > 0 ) {
 if ( isset($_GET['delete']) ) {
     $studenturl = Table::makeUrl('student.php', $getparms);
     echo('<form method="post">
+        '.\Tsugi\Controllers\Tool::csrfField().'
         <input type="hidden" name="user_id" value="'.$user_id.'">
         <label for="deleteNote">Enter an optional note to send to the student</label><br/>
         <textarea name="deleteNote" id="deleteNote" style="width:60%" rows="5">
@@ -429,6 +437,7 @@ if ( $assn_json->totalpoints == 0 ) {
     if ( isset($_GET['resend']) ) {
         $studenturl = Table::makeUrl('student.php', $getparms);
         echo('<form method="post">
+            '.\Tsugi\Controllers\Tool::csrfField().'
             <input type="hidden" name="user_id" value="'.$user_id.'">
             <input type="submit" name="resendSubmit" value="Resend the Grade" class="btn btn-warning">
             <input type="submit" name="doCancel" value="Cancel Resend" class="btn btn-normal"
@@ -454,7 +463,7 @@ if ( $our_flags !== false && count($our_flags) > 0 ) {
         echo("<td>".htmlentities($flag['email'] ?? '')."</td>\n");
         echo("<td>".htmlentities($flag['note'] ?? '')."</td>\n");
         echo("<td>".htmlentities($flag['updated_at'] ?? '')."</td>\n");
-        echo('<td> <form method="post"><input type="hidden"
+        echo('<td> <form method="post">'.\Tsugi\Controllers\Tool::csrfField().'<input type="hidden"
             name="flag_id" value="'.$flag['flag_id'].'">
         <input type="submit" name="deleteFlag" value="delete" class="btn btn-danger"></form></td>');
         echo("</tr>\n");
@@ -481,7 +490,7 @@ if ( $grades_received === false || count($grades_received) < 1 ) {
         if ( $assn_json->peerpoints > 0 ) echo("<td>".$grade['points']."</td>");
         if ( $assn_json->rating > 0 ) echo("<td>".$grade['rating']."</td>");
         echo("<td>".htmlentities($grade['note'] ?? '')."</td>".
-        '<td> <form method="post"><input type="hidden"
+        '<td> <form method="post">'.\Tsugi\Controllers\Tool::csrfField().'<input type="hidden"
             name="grade_id" value="'.$grade['grade_id'].'">
         <input type="hidden" name="user_id" value="'.$user_id.'">
         <input type="submit" name="deleteGrade" value="delete" class="btn btn-danger"></form></td>'.
@@ -513,7 +522,7 @@ if ( $grades_given === false || count($grades_given) < 1 ) {
         if ( $assn_json->peerpoints > 0 ) echo("<td>".$grade['points']."</td>");
         if ( $assn_json->rating > 0 ) echo("<td>".$grade['rating']."</td>");
         echo("<td>".htmlentities($grade['note'] ?? '')."</td>".
-        '<td> <form method="post"><input type="hidden"
+        '<td> <form method="post">'.\Tsugi\Controllers\Tool::csrfField().'<input type="hidden"
             name="grade_id" value="'.$grade['grade_id'].'">
         <input type="hidden" name="user_id" value="'.$user_id.'">
         <input type="submit" name="deleteGrade" value="delete" class="btn btn-danger"></form></td>'.

--- a/tool/tdiscus/api/addsubcomment.php
+++ b/tool/tdiscus/api/addsubcomment.php
@@ -15,6 +15,11 @@ $LTI = LTIX::requireData();
 
 $THREADS = new Threads();
 
+if ( ! \Tsugi\Controllers\Tool::csrfOk() ) {
+    Net::send400('Missing or invalid CSRF token');
+    return;
+}
+
 $thread_id = U::get($_POST, 'thread_id');
 $comment_id = U::get($_POST, 'comment_id');
 $comment = U::get($_POST, 'comment');

--- a/tool/tdiscus/api/commentsetboolean.php
+++ b/tool/tdiscus/api/commentsetboolean.php
@@ -12,6 +12,11 @@ $LTI = LTIX::requireData();
 
 $THREADS = new Threads();
 
+if ( ! \Tsugi\Controllers\Tool::csrfOk() ) {
+    Net::send400('Missing or invalid CSRF token');
+    return;
+}
+
 $rest_path = U::rest_path();
 $comment_id = $rest_path->action;
 if ( count($rest_path->parameters) != 2 ) {

--- a/tool/tdiscus/api/threadsetboolean.php
+++ b/tool/tdiscus/api/threadsetboolean.php
@@ -12,6 +12,11 @@ $LTI = LTIX::requireData();
 
 $THREADS = new Threads();
 
+if ( ! \Tsugi\Controllers\Tool::csrfOk() ) {
+    Net::send400('Missing or invalid CSRF token');
+    return;
+}
+
 $rest_path = U::rest_path();
 $thread_id = $rest_path->action;
 if ( count($rest_path->parameters) != 2 ) {

--- a/tool/tdiscus/api/threadusersetboolean.php
+++ b/tool/tdiscus/api/threadusersetboolean.php
@@ -12,6 +12,11 @@ $LTI = LTIX::requireData();
 
 $THREADS = new Threads();
 
+if ( ! \Tsugi\Controllers\Tool::csrfOk() ) {
+    Net::send400('Missing or invalid CSRF token');
+    return;
+}
+
 $rest_path = U::rest_path();
 $thread_id = $rest_path->action;
 if ( count($rest_path->parameters) != 2 ) {

--- a/tool/tdiscus/commentform.php
+++ b/tool/tdiscus/commentform.php
@@ -34,6 +34,9 @@ if ( isset($rest_path->action) && is_numeric($rest_path->action) ) {
 }
 
 if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession($TOOL_ROOT . '/' . $come_back)) ) {
+        return;
+    }
     $retval = $THREADS->commentUpdateDao($old_comment, U::get($_POST, 'comment'));
     if ( is_string($retval) ) {
         $_SESSION['error'] = $retval;
@@ -60,6 +63,7 @@ if ( $old_comment ) {
 ?>
 <div id="edit-comment-div" title="<?= __("Comment") ?>" role="region" aria-labelledby="edit-comment-heading">
 <form id="edit-comment-form" method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>
 <label for="edit-comment-input"><?= __("Comment:") ?></label><br/>
 <input type="text" id="edit-comment-input" name="comment" class="form-control" aria-required="true"

--- a/tool/tdiscus/commentremove.php
+++ b/tool/tdiscus/commentremove.php
@@ -35,6 +35,9 @@ $come_back = $TOOL_ROOT . '/commentremove/' . $comment_id;
 $all_done = $TOOL_ROOT.'/thread/'.$thread_id;
 
 if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession($come_back)) ) {
+        return;
+    }
     $retval = $THREADS->commentDelete($comment_id, $thread_id);
     if ( is_string($retval) ) {
         $_SESSION['error'] = $retval;
@@ -59,6 +62,7 @@ echo("<h1 id=\"delete-comment-heading\">".__('Delete Comment')."</h1>\n");
 ?>
 <div id="delete-comment-div" title="<?= __("Delete comment") ?>" role="region" aria-labelledby="delete-comment-heading">
 <form id="delete-comment-form" method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p><?= __("Comment:") ?><br/>
 <?php
 echo('<b>'.htmlentities($old_comment['comment'] ?? '').'</b><br/>');

--- a/tool/tdiscus/thread.php
+++ b/tool/tdiscus/thread.php
@@ -23,6 +23,17 @@ $thread_id = null;
 $thread = null;
 if ( isset($rest_path->action) && is_numeric($rest_path->action) ) {
     $thread_id = intval($rest_path->action);
+}
+
+$come_back = $TOOL_ROOT . '/thread/' . $thread_id;
+
+if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession($come_back)) ) {
+        return;
+    }
+}
+
+if ( $thread_id !== null ) {
     $thread = $THREADS->threadLoadMarkRead($thread_id);
 }
 
@@ -34,7 +45,6 @@ if ( ! $thread ) {
     return;
 }
 
-$come_back = $TOOL_ROOT . '/thread/' . $thread_id;
 $all_done = $TOOL_ROOT . '/';
 $discussion_title = (strlen($LAUNCH->link->settingsGet('title')) > 0)
     ? $LAUNCH->link->settingsGet('title')
@@ -42,9 +52,6 @@ $discussion_title = (strlen($LAUNCH->link->settingsGet('title')) > 0)
 $threads_index_url = U::addSession($TOOL_ROOT . '/');
 
 if ( count($_POST) > 0 ) {
-    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession($come_back)) ) {
-        return;
-    }
     $retval = $THREADS->commentInsertDao($thread, U::get($_POST, 'comment') );
     if ( is_string($retval) ) {
         $_SESSION['error'] = $retval;

--- a/tool/tdiscus/thread.php
+++ b/tool/tdiscus/thread.php
@@ -42,6 +42,9 @@ $discussion_title = (strlen($LAUNCH->link->settingsGet('title')) > 0)
 $threads_index_url = U::addSession($TOOL_ROOT . '/');
 
 if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession($come_back)) ) {
+        return;
+    }
     $retval = $THREADS->commentInsertDao($thread, U::get($_POST, 'comment') );
     if ( is_string($retval) ) {
         $_SESSION['error'] = $retval;

--- a/tool/tdiscus/threadform.php
+++ b/tool/tdiscus/threadform.php
@@ -34,6 +34,9 @@ if ( isset($rest_path->action) && is_numeric($rest_path->action) ) {
 }
 
 if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession($TOOL_ROOT . '/' . $come_back)) ) {
+        return;
+    }
     if ( $old_thread ) {
         $retval = $THREADS->threadUpdate($thread_id, $_POST);
         if ( is_string($retval) ) {
@@ -74,6 +77,7 @@ if ( $old_thread ) {
 ?>
 <div id="add-thread-div" title="<?= __("New Thread") ?>" role="region" aria-labelledby="add-thread-heading">
 <form id="add-thread-form" method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>
 <label for="add-thread-title"><?= __("Title:") ?></label><br/>
 <input type="text" id="add-thread-title" name="title" class="form-control" aria-required="true"

--- a/tool/tdiscus/threadremove.php
+++ b/tool/tdiscus/threadremove.php
@@ -34,6 +34,9 @@ if ( ! $old_thread ) {
 }
 
 if ( count($_POST) > 0 ) {
+    if ( \Tsugi\Controllers\Tool::csrfRedirect(addSession($TOOL_ROOT . '/' . $come_back)) ) {
+        return;
+    }
     $retval = $THREADS->threadDelete($thread_id);
     if ( is_string($retval) ) {
         $_SESSION['error'] = $retval;
@@ -66,6 +69,7 @@ echo('<b>'.htmlentities($old_thread['title'] ?? '').'</b><br/>');
 <?= $purifier->purify($old_thread['body']) ?>
 </p>
 <form id="delete-thread-form" method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>
 <input type="submit" id="delete-thread-submit" value="<?= __('Delete') ?>" >
 <button type="button" id="delete-thread-cancel" onclick='window.location.href="<?= addSession($TOOL_ROOT.'/') ?>";'><?= __('Cancel') ?></button>

--- a/tool/tdiscus/util/tdiscus.php
+++ b/tool/tdiscus/util/tdiscus.php
@@ -160,6 +160,7 @@ foreach($sortby as $sort) {
 ?>
 <div id="tdiscus-add-comment-div" class="tdiscus-add-comment-container" title="<?= __("Reply") ?>" role="region" aria-label="<?= htmlspecialchars(__("Add reply")) ?>">
 <form id="tdiscus-add-comment-form" method="post">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>
 <label for="tdiscus-add-comment-text-<?= $thread_id ?>" class="tdiscus-visually-hidden"><?= __("Your reply") ?></label>
 <textarea id="tdiscus-add-comment-text-<?= $thread_id ?>" style="width:100%;" class="tdiscus-add-sub-comment-text form-control" name="comment" aria-label="<?= htmlspecialchars(__("Your reply")) ?>">
@@ -180,6 +181,7 @@ foreach($sortby as $sort) {
 <form method="post" 
     data-click-done="<?= $html_id ?>_toggle" 
     class="tdiscus-add-sub-comment-form">
+<?= \Tsugi\Controllers\Tool::csrfField() ?>
 <p>
 <input type="hidden" name="comment_id" value="<?= $comment_id ?>">
 <input type="hidden" name="thread_id" value="<?= $thread_id ?>">
@@ -295,7 +297,11 @@ $(document).ready( function() {
         ev.preventDefault()
         if ( ! confirm($(this).attr('data-confirm')) ) return;
         var data_class = $(this).attr('data-class');
-        $.post(addSession('<?= self::toolRoot() ?>'+'/api/'+$(this).attr('data-endpoint')))
+        $.ajax({
+            url: addSession('<?= self::toolRoot() ?>'+'/api/'+$(this).attr('data-endpoint')),
+            method: 'POST',
+            headers: tsugiCsrfHeaders()
+        })
             .done( function(data) {
                 $('.'+data_class).toggle();
             })
@@ -337,7 +343,12 @@ $(document).ready( function() {
        // Hide during the processing
        if ( click_done ) $('#'+click_done).click();
        $(this).find('textarea[name="comment"]').val('');
-       $.post(addSession('<?= self::toolRoot() ?>/api/addsubcomment'), ser)
+       $.ajax({
+           url: addSession('<?= self::toolRoot() ?>/api/addsubcomment'),
+           method: 'POST',
+           data: ser,
+           headers: tsugiCsrfHeaders()
+       })
             .done( function(data) {
                 console.log('data', data);
                 // if ( comment.length > 0 ) txt3.innerHTML = htmlentities(comment);


### PR DESCRIPTION
LTI launches and signed webhooks stay exempt; HTML forms and same-origin AJAX now share Tool helpers and fail closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Expanded CSRF protection across administrative tools, forms, APIs, and interactive workflows.
  * Forms and asynchronous requests now include security tokens automatically.
  * Requests with missing or invalid tokens are blocked before updates, deletions, messages, or other data changes occur.
  * Rejected submissions receive appropriate redirects or clear error responses.
  * Improved support for secure same-origin form submissions.
  * Admin sessions no longer regenerate on every console page load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->