### PR TITLE
Add high-contrast themes and let profile override site or course.

### DIFF
--- a/lib/src/Controllers/Profile.php
+++ b/lib/src/Controllers/Profile.php
@@ -54,11 +54,11 @@ class Profile extends Controller {
         if ( ! is_object($profile) ) $profile = new \stdClass();
 
         $themeId = 0;
-        // Load data from the profile, if it exists
         if (isset($profile->theme_override)) {
-            if ($profile->theme_override == 'light') {
+            $themeKey = \Tsugi\Core\Manifest::profileThemeKey($profile->theme_override);
+            if ( $themeKey === 'hc-bow' ) {
                 $themeId = 1;
-            } else if ($profile->theme_override == 'dark') {
+            } else if ( $themeKey === 'hc-wob' ) {
                 $themeId = 2;
             }
         }
@@ -130,19 +130,19 @@ echo(' ('.htmlentities($_SESSION['email']).")</h1>\n");
             <div style="display: flex; justify-content: space-between;">
                 <fieldset class="control-group">
                     <legend>Would you like to set a theme override?</legend>
-                    <p><em>Overrides will only show if theme information is set in the launch data (such as from an LMS) or configured.</em></p>
+                    <p><em>A high-contrast choice overrides the site or course theme on every page. Default uses the site or course theme.</em></p>
                     <div class="controls">
                         <label class="radio">
                             <?php self::radio('theme',0,$themeId); ?>
-                            Use the default configuration
+                            Use default theme for site
                         </label>
                         <label class="radio">
                             <?php self::radio('theme',1,$themeId); ?>
-                            Use light theme
+                            Use high contrast black on white theme
                         </label>
                         <label class="radio">
                             <?php self::radio('theme',2,$themeId); ?>
-                            Use dark theme
+                            Use high contrast white on black theme
                         </label>
                     </div>
                 </fieldset>
@@ -273,9 +273,9 @@ Send me notification mail for important things like my assignment was graded.
         $profile->subscribe = $_POST['subscribe']+0 ;
 
         if ($_POST['theme'] == 1) {
-            $profile->theme_override = 'light';
+            $profile->theme_override = 'hc-bow';
         } else if ($_POST['theme'] == 2) {
-            $profile->theme_override = 'dark';
+            $profile->theme_override = 'hc-wob';
         } else {
             $profile->theme_override = null;
         }

--- a/lib/src/Controllers/templates/Setup/theme_picker.inc.php
+++ b/lib/src/Controllers/templates/Setup/theme_picker.inc.php
@@ -66,11 +66,12 @@ if ( ! isset($theme_site_primary) || ! is_string($theme_site_primary) || $theme_
     <?php foreach ( $theme_palettes as $key => $palette ) {
         $label = isset($palette['label']) ? $palette['label'] : $key;
         $primary = isset($palette['primary']) ? $palette['primary'] : '#999999';
+        $bg = isset($palette['background-color']) ? $palette['background-color'] : $primary;
         $selected = ($theme_current === $key);
         ?>
         <label class="theme-swatch">
             <input type="radio" name="theme" value="<?= htmlspecialchars($key) ?>"<?= $selected ? ' checked' : '' ?> />
-            <span class="theme-swatch-bar" style="background: <?= htmlspecialchars($primary) ?>;"></span>
+            <span class="theme-swatch-bar" style="background: linear-gradient(to right, <?= htmlspecialchars($primary) ?> 50%, <?= htmlspecialchars($bg) ?> 50%);"></span>
             <span class="theme-swatch-label"><?= htmlspecialchars($label) ?></span>
         </label>
     <?php } ?>

--- a/lib/src/Core/Manifest.php
+++ b/lib/src/Core/Manifest.php
@@ -182,7 +182,61 @@ class Manifest {
                 'font-family' => 'sans-serif',
                 'font-size' => '14px',
             ),
+            'hc-bow' => array(
+                'label' => 'High contrast black on white',
+                'primary' => '#000000',
+                'primary-menu' => '#000000',
+                'primary-border' => '#000000',
+                'primary-darker' => '#000000',
+                'primary-darkest' => '#000000',
+                'background-color' => '#FFFFFF',
+                'background-focus' => '#FFFFFF',
+                'background-accent' => '#000000',
+                'secondary' => '#FFFFFF',
+                'secondary-menu' => '#FFFFFF',
+                'text' => '#000000',
+                'text-light' => '#000000',
+                'font-family' => 'sans-serif',
+                'font-size' => '14px',
+            ),
+            'hc-wob' => array(
+                'label' => 'High contrast white on black',
+                'primary' => '#FFFFFF',
+                'primary-menu' => '#FFFFFF',
+                'primary-border' => '#FFFFFF',
+                'primary-darker' => '#FFFFFF',
+                'primary-darkest' => '#FFFFFF',
+                'background-color' => '#000000',
+                'background-focus' => '#000000',
+                'background-accent' => '#FFFFFF',
+                'secondary' => '#000000',
+                'secondary-menu' => '#000000',
+                'text' => '#FFFFFF',
+                'text-light' => '#FFFFFF',
+                'font-family' => 'sans-serif',
+                'font-size' => '14px',
+            ),
         );
+    }
+
+    /**
+     * Palette key from a profile theme_override, or null to keep site/course theme.
+     *
+     * Maps legacy light/dark overrides to the high-contrast palettes.
+     *
+     * @return string|null
+     */
+    public static function profileThemeKey($override) {
+        if ( $override === 'light' ) {
+            $override = 'hc-bow';
+        } else if ( $override === 'dark' ) {
+            $override = 'hc-wob';
+        }
+        $norm = self::normalizeThemeKey($override);
+        if ( $norm === 'hc-bow' || $norm === 'hc-wob' ) {
+            return $norm;
+        }
+        return null;
     }
 
     /**
@@ -200,7 +254,7 @@ class Manifest {
             return null;
         }
         $p = $all[$norm];
-        unset($p['label']);
+        unset($p['label'], $p['swatch']);
         return $p;
     }
 

--- a/lib/src/UI/Output.php
+++ b/lib/src/UI/Output.php
@@ -1382,7 +1382,8 @@ $( function() {
             }
         }
 
-        // Override the config AND launch values if the user's preference is set in the $_SESSION
+        // Profile high-contrast override wins over site, launch, and course theme.
+        $profile_theme_key = null;
         if ( is_object($PDOX) && isset($_SESSION) && isset($_SESSION['profile_id']) ) {
             $profile_table = "{$CFG->dbprefix}profile";
             if ( $PDOX->metadata($profile_table) !== false ) {
@@ -1397,21 +1398,32 @@ $( function() {
                     if ( ! empty($profile_row) && ! is_null($profile_row['json']) ) {
                         $profile = json_decode($profile_row['json']);
                         if ( isset($profile->theme_override) ) {
-                            if ( $profile->theme_override == 'dark' ) {
-                                $dark_mode = true;
-                            } else if ( $profile->theme_override == 'light' ) {
-                                $dark_mode = null;
-                            }
+                            $profile_theme_key = Manifest::profileThemeKey($profile->theme_override);
                         }
                     }
                 }
             }
         }
 
+        if ( $profile_theme_key === 'hc-wob' ) {
+            $dark_mode = true;
+        } else if ( $profile_theme_key === 'hc-bow' ) {
+            $dark_mode = null;
+        }
+
         // Set dark mode configuration on the theme so apps can check
         // Example: conditional rendering of a twitter embed attribute
         Theme::$dark_mode = $dark_mode;
         Theme::$theme_base = $theme_base;
+
+        if ( is_string($profile_theme_key) ) {
+            $forced = Manifest::palette($profile_theme_key);
+            if ( is_array($forced) ) {
+                $theme = self::themeDefaultsPreservingFont($forced);
+                if (is_object($TSUGI_LAUNCH)) $_SESSION['tsugi_theme'] = $theme;
+                return $theme;
+            }
+        }
 
         $courseTheme = null;
         if ( Manifest::activeId() > 0 ) {

--- a/lib/tests/Core/ManifestTest.php
+++ b/lib/tests/Core/ManifestTest.php
@@ -350,6 +350,12 @@ class ManifestTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('navy', $palettes);
         $this->assertArrayHasKey('electric', $palettes);
         $this->assertArrayHasKey('grey', $palettes);
+        $this->assertArrayHasKey('hc-bow', $palettes);
+        $this->assertArrayHasKey('hc-wob', $palettes);
+        $this->assertSame('#000000', $palettes['hc-bow']['text']);
+        $this->assertSame('#FFFFFF', $palettes['hc-bow']['background-color']);
+        $this->assertSame('#FFFFFF', $palettes['hc-wob']['text']);
+        $this->assertSame('#000000', $palettes['hc-wob']['background-color']);
         $this->assertSame('#0D47A1', $palettes['tsugi']['primary']);
         $this->assertSame('#0a4b33', $palettes['django']['primary']);
         $this->assertSame('#336791', $palettes['postgres']['primary']);
@@ -368,6 +374,11 @@ class ManifestTest extends \PHPUnit\Framework\TestCase
         $this->assertNull(Manifest::normalizeThemeKey('site'));
         $this->assertNull(Manifest::normalizeThemeKey(null));
         $this->assertSame('django', Manifest::normalizeThemeKey('Django'));
+        $this->assertSame('hc-bow', Manifest::normalizeThemeKey('hc-bow'));
+        $this->assertSame('hc-wob', Manifest::profileThemeKey('hc-wob'));
+        $this->assertSame('hc-bow', Manifest::profileThemeKey('light'));
+        $this->assertSame('hc-wob', Manifest::profileThemeKey('dark'));
+        $this->assertNull(Manifest::profileThemeKey(null));
         $this->assertFalse(Manifest::normalizeThemeKey('not-a-theme'));
         $this->assertFalse(Manifest::normalizeThemeKey(array('django')));
         $this->assertNull(Manifest::palette(''));


### PR DESCRIPTION
## Summary
- Replace profile light/dark options with site default, high-contrast black on white, and high-contrast white on black.
- Offer the same two palettes in course Setup for any manifest-backed course.
- A profile high-contrast choice wins over the course or site theme. Legacy `light`/`dark` profile values map to the new palettes.

## Test plan
- [ ] Log in, open `/profile`, confirm the three radio labels, save default vs each high-contrast option
- [ ] Confirm the chosen high-contrast theme applies on other pages (home, a course)
- [ ] In `/setup`, pick each new swatch and confirm the course uses it when profile is “default theme for site”
- [ ] Set a course theme, then override it from profile and confirm profile wins
- [ ] `qa/test-lib.sh tests/Core/ManifestTest.php`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added high-contrast black-on-white and white-on-black theme options.
  * Updated profile theme settings with clearer labels and descriptions.
  * Improved theme picker swatches to display both primary and background colors.

* **Bug Fixes**
  * Preserved compatibility with existing light and dark theme selections while applying the corresponding high-contrast themes.

* **Tests**
  * Added coverage for high-contrast palettes and theme selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->