### PR TITLE
Relaunch iframe LTI POSTs after a browser reload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ This folder is the Tsugi you are editing. A sibling clone often exists at `/User
 ## Testing Guidelines
 - This repository does not include a formal automated test suite; `test/old_test.php` is legacy.
 - Validate changes manually by running the app, visiting key admin screens, and re-running the database upgrade flow if schema changes are involved.
+- **App Store test harness (no login):** anything under `mod/` and anything under `tool/` can be launched from the store without signing in. Start at `$CFG->wwwroot/tool` (redirects to the store) or go directly to `$CFG->wwwroot/store/test/{name}` (for example `/tsugi/store/test/trophy`). Use **Try It**, pick an identity (Jane Instructor or a student), and exercise the tool in the iframe. Some instructor views (Trophy is one) show a launch var dump — that is expected, not a broken page. Do not assume a site login is required for this path.
 
 ## Commit & Pull Request Guidelines
 - Recent commits are short, sentence-style summaries (e.g., “Add item to headers.”). Keep messages concise and action-oriented.

--- a/lib/src/UI/Output.php
+++ b/lib/src/UI/Output.php
@@ -1242,8 +1242,12 @@ EOF;
 ?>
    </head>
 <body>
+<div class="container" style="padding: 2em;">
+  <h2><?= htmlentities($message) ?></h2>
+  <p><?= htmlentities($detail) ?></p>
+</div>
 <div id="dialog-confirm" style="display:none;" title="<?= htmlentities($message) ?>">
-<p><span class="ui-icon ui-icon-alert" style="float:left; margin:12px 12px 20px 0;"></span><?= $detail ?></p>
+<p><span class="ui-icon ui-icon-alert" style="float:left; margin:12px 12px 20px 0;"></span><?= htmlentities($detail) ?></p>
 </div>
 <?= self::footerScriptLinks() ?>
 <script>

--- a/lib/src/Util/LTI.php
+++ b/lib/src/Util/LTI.php
@@ -250,7 +250,7 @@ class LTI {
                 $frame_title = 'LTI tool content';
             }
             $frame_title_esc = htmlspecialchars($frame_title, ENT_QUOTES, 'UTF-8');
-            $r .= "<iframe class=\"lti_frameResize\" name=\"".$frame_id."\" id=\"".$frame_id."\" src=\"\" title=\"".$frame_title_esc."\"\n";
+            $r .= "<iframe class=\"lti_frameResize\" name=\"".$frame_id."\" id=\"".$frame_id."\" src=\"about:blank\" title=\"".$frame_title_esc."\"\n";
             $r .= $iframeattr . ">\n";
             $frames_msg = self::get_string("frames_required","basiclti");
             if ( $frames_msg === 'frames_required' ) {
@@ -258,35 +258,105 @@ class LTI {
             }
             $r .= "<p>".htmlspecialchars($frames_msg)."</p>\n</iframe>\n";
         }
-        // Remove session_name (i.e. PHPSESSID) if it was added.
+        $ext_submit = "ext_submit";
+        $ext_submit_text = $submit_text;
+        $do_autosubmit = ( ! $debug ) && $iframeattr != '_pause';
+        // Fresh GET (location-bar Enter) creates an empty iframe, then this
+        // script POSTs the LTI launch into it. Reload is different: the
+        // browser restores the iframe's previous POST document, that restore
+        // fails, and the frame stays about:blank. Wait until pageshow on
+        // reload, wipe the restored frame, then submit into a clean target.
         $r .= " <script type=\"text/javascript\"> \n" .
             "  //<![CDATA[ \n" .
-            "    var inputs = document.getElementById(\"".$form_id."\").childNodes;\n" .
-            "    for (var i = 0; i < inputs.length; i++)\n" .
-            "    {\n" .
-            "        var thisinput = inputs[i];\n" .
-            "        if ( thisinput.name != '".session_name()."' ) continue;\n" .
-            "        thisinput.parentNode.removeChild(thisinput);\n" .
+            "  (function() {\n" .
+            "    var fid = ".json_encode($form_id).";\n" .
+            "    var frameId = ".json_encode($frame_id).";\n" .
+            "    var sess = ".json_encode(session_name()).";\n" .
+            "    var autosubmit = ".($do_autosubmit ? 'true' : 'false').";\n" .
+            "    var extName = ".json_encode($ext_submit).";\n" .
+            "    var extVal = ".json_encode($ext_submit_text).";\n" .
+            "    var prepared = false;\n" .
+            "    function isReloadNav() {\n" .
+            "      try {\n" .
+            "        var n = performance.getEntriesByType && performance.getEntriesByType('navigation')[0];\n" .
+            "        if ( n && n.type === 'reload' ) return true;\n" .
+            "      } catch (e) {}\n" .
+            "      try {\n" .
+            "        if ( performance.navigation && performance.navigation.type === 1 ) return true;\n" .
+            "      } catch (e) {}\n" .
+            "      return false;\n" .
             "    }\n" .
+            "    function iframeIsBlank() {\n" .
+            "      var ifr = document.getElementById(frameId);\n" .
+            "      if ( ! ifr ) return false;\n" .
+            "      try {\n" .
+            "        var href = ifr.contentWindow.location.href;\n" .
+            "        return ! href || href === 'about:blank';\n" .
+            "      } catch (e) {\n" .
+            "        return false;\n" .
+            "      }\n" .
+            "    }\n" .
+            "    function prepareForm(form) {\n" .
+            "      if ( prepared ) return;\n" .
+            "      prepared = true;\n" .
+            "      var inputs = form.childNodes;\n" .
+            "      for (var i = inputs.length - 1; i >= 0; i--) {\n" .
+            "        var thisinput = inputs[i];\n" .
+            "        if ( thisinput.name != sess ) continue;\n" .
+            "        thisinput.parentNode.removeChild(thisinput);\n" .
+            "      }\n" .
+            "      form.style.display = 'none';\n" .
+            "      var nei = document.createElement('input');\n" .
+            "      nei.setAttribute('type', 'hidden');\n" .
+            "      nei.setAttribute('name', extName);\n" .
+            "      nei.setAttribute('value', extVal);\n" .
+            "      form.appendChild(nei);\n" .
+            "    }\n" .
+            "    function tsugiLaunchForm() {\n" .
+            "      var form = document.getElementById(fid);\n" .
+            "      if ( ! form || form.getAttribute('data-tsugi-submitted') ) return;\n" .
+            "      prepareForm(form);\n" .
+            "      if ( ! autosubmit ) return;\n" .
+            "      form.setAttribute('data-tsugi-submitted', '1');\n" .
+            "      var ifr = document.getElementById(frameId);\n" .
+            "      var go = function() {\n" .
+            "        form.submit();\n" .
+            "        console.log('Autosubmitted ' + fid);\n" .
+            "      };\n" .
+            "      if ( ! ifr ) { go(); return; }\n" .
+            "      var fired = false;\n" .
+            "      var once = function() {\n" .
+            "        if ( fired ) return;\n" .
+            "        fired = true;\n" .
+            "        ifr.removeEventListener('load', once);\n" .
+            "        go();\n" .
+            "      };\n" .
+            "      ifr.addEventListener('load', once);\n" .
+            "      try { ifr.contentWindow.location.replace('about:blank'); }\n" .
+            "      catch (e) { ifr.src = 'about:blank'; }\n" .
+            "      setTimeout(once, 50);\n" .
+            "    }\n" .
+            "    if ( isReloadNav() ) {\n" .
+            "      window.addEventListener('pageshow', function() {\n" .
+            "        if ( ! iframeIsBlank() ) return;\n" .
+            "        var form = document.getElementById(fid);\n" .
+            "        if ( form ) form.removeAttribute('data-tsugi-submitted');\n" .
+            "        tsugiLaunchForm();\n" .
+            "      });\n" .
+            "    } else if ( document.readyState === 'loading' ) {\n" .
+            "      document.addEventListener('DOMContentLoaded', tsugiLaunchForm);\n" .
+            "    } else {\n" .
+            "      tsugiLaunchForm();\n" .
+            "    }\n" .
+            "    window.addEventListener('pageshow', function(ev) {\n" .
+            "      if ( ! autosubmit || ! ev.persisted ) return;\n" .
+            "      var form = document.getElementById(fid);\n" .
+            "      if ( form ) form.removeAttribute('data-tsugi-submitted');\n" .
+            "      tsugiLaunchForm();\n" .
+            "    });\n" .
+            "  })();\n" .
             "  //]]> \n" .
             " </script> \n";
-
-        if ( ( ! $debug ) && $iframeattr != '_pause' ) {
-            $ext_submit = "ext_submit";
-            $ext_submit_text = $submit_text;
-            $r .= " <script type=\"text/javascript\"> \n" .
-                "  //<![CDATA[ \n" .
-                "    document.getElementById(\"".$form_id."\").style.display = \"none\";\n" .
-                "    nei = document.createElement('input');\n" .
-                "    nei.setAttribute('type', 'hidden');\n" .
-                "    nei.setAttribute('name', '".$ext_submit."');\n" .
-                "    nei.setAttribute('value', '".$ext_submit_text."');\n" .
-                "    document.getElementById(\"".$form_id."\").appendChild(nei);\n" .
-                "    document.getElementById(\"".$form_id."\").submit(); \n" .
-                "    console.log('Autosubmitted ".$form_id."'); \n" .
-                "  //]]> \n" .
-                " </script> \n";
-        }
         return $r;
     }
 

--- a/lib/src/Util/LTI.php
+++ b/lib/src/Util/LTI.php
@@ -276,6 +276,7 @@ class LTI {
             "    var extName = ".json_encode($ext_submit).";\n" .
             "    var extVal = ".json_encode($ext_submit_text).";\n" .
             "    var prepared = false;\n" .
+            "    var reloadLaunched = false;\n" .
             "    function isReloadNav() {\n" .
             "      try {\n" .
             "        var n = performance.getEntriesByType && performance.getEntriesByType('navigation')[0];\n" .
@@ -296,15 +297,18 @@ class LTI {
             "        return false;\n" .
             "      }\n" .
             "    }\n" .
-            "    function prepareForm(form) {\n" .
-            "      if ( prepared ) return;\n" .
-            "      prepared = true;\n" .
+            "    function stripSessionInput(form) {\n" .
             "      var inputs = form.childNodes;\n" .
             "      for (var i = inputs.length - 1; i >= 0; i--) {\n" .
             "        var thisinput = inputs[i];\n" .
             "        if ( thisinput.name != sess ) continue;\n" .
             "        thisinput.parentNode.removeChild(thisinput);\n" .
             "      }\n" .
+            "    }\n" .
+            "    function prepareForm(form) {\n" .
+            "      if ( prepared ) return;\n" .
+            "      prepared = true;\n" .
+            "      stripSessionInput(form);\n" .
             "      form.style.display = 'none';\n" .
             "      var nei = document.createElement('input');\n" .
             "      nei.setAttribute('type', 'hidden');\n" .
@@ -315,8 +319,11 @@ class LTI {
             "    function tsugiLaunchForm() {\n" .
             "      var form = document.getElementById(fid);\n" .
             "      if ( ! form || form.getAttribute('data-tsugi-submitted') ) return;\n" .
+            "      if ( ! autosubmit ) {\n" .
+            "        stripSessionInput(form);\n" .
+            "        return;\n" .
+            "      }\n" .
             "      prepareForm(form);\n" .
-            "      if ( ! autosubmit ) return;\n" .
             "      form.setAttribute('data-tsugi-submitted', '1');\n" .
             "      var ifr = document.getElementById(frameId);\n" .
             "      var go = function() {\n" .
@@ -338,9 +345,11 @@ class LTI {
             "    }\n" .
             "    if ( isReloadNav() ) {\n" .
             "      window.addEventListener('pageshow', function() {\n" .
+            "        reloadLaunched = false;\n" .
             "        if ( ! iframeIsBlank() ) return;\n" .
             "        var form = document.getElementById(fid);\n" .
             "        if ( form ) form.removeAttribute('data-tsugi-submitted');\n" .
+            "        reloadLaunched = true;\n" .
             "        tsugiLaunchForm();\n" .
             "      });\n" .
             "    } else if ( document.readyState === 'loading' ) {\n" .
@@ -349,7 +358,7 @@ class LTI {
             "      tsugiLaunchForm();\n" .
             "    }\n" .
             "    window.addEventListener('pageshow', function(ev) {\n" .
-            "      if ( ! autosubmit || ! ev.persisted ) return;\n" .
+            "      if ( ! autosubmit || ! ev.persisted || reloadLaunched ) return;\n" .
             "      var form = document.getElementById(fid);\n" .
             "      if ( form ) form.removeAttribute('data-tsugi-submitted');\n" .
             "      tsugiLaunchForm();\n" .

--- a/lib/tests/Util/LTITest.php
+++ b/lib/tests/Util/LTITest.php
@@ -705,6 +705,24 @@ class LTITest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('basiclti_base_string', $html);
     }
 
+    public function testPostLaunchHTMLManualLaunchDoesNotPrepareForm() {
+        $signed = \Tsugi\Util\LTI::signParameters($this->parms, $this->endpoint, 'POST', '12345', 'secret', 'Launch', false, false, 'width="100%"');
+        $debug = \Tsugi\Util\LTI::postLaunchHTML($signed, $this->endpoint, true, 'width="100%"');
+        $this->assertStringContainsString('var autosubmit = false;', $debug);
+        $this->assertStringContainsString('<input type="submit" name="ext_submit"', $debug);
+        $this->assertMatchesRegularExpression('/function tsugiLaunchForm\(\) \{.*?if \( ! autosubmit \).*?prepareForm\(form\);/s', $debug);
+
+        $pause = \Tsugi\Util\LTI::postLaunchHTML($signed, $this->endpoint, false, '_pause');
+        $this->assertStringContainsString('var autosubmit = false;', $pause);
+        $this->assertStringContainsString('<input type="hidden" name="ext_submit"', $pause);
+        $this->assertStringNotContainsString('<input type="submit" name="ext_submit"', $pause);
+
+        $auto = \Tsugi\Util\LTI::postLaunchHTML($signed, $this->endpoint, false, 'width="100%"');
+        $this->assertStringContainsString('var autosubmit = true;', $auto);
+        $this->assertStringContainsString('if ( ! autosubmit || ! ev.persisted || reloadLaunched ) return;', $auto);
+        $this->assertMatchesRegularExpression('/reloadLaunched = false;.*?reloadLaunched = true;.*?tsugiLaunchForm\(\);/s', $auto);
+    }
+
     public function testPostLaunchHTMLWithEndform() {
         $signed = \Tsugi\Util\LTI::signParameters($this->parms, $this->endpoint, 'POST', '12345', 'secret', 'Launch', false, false, '_pause');
         $html = \Tsugi\Util\LTI::postLaunchHTML($signed, $this->endpoint, false, '_pause', '<div class="extra">extra content</div>');

--- a/lib/tests/Util/LTITest.php
+++ b/lib/tests/Util/LTITest.php
@@ -720,7 +720,8 @@ class LTITest extends \PHPUnit\Framework\TestCase
         $auto = \Tsugi\Util\LTI::postLaunchHTML($signed, $this->endpoint, false, 'width="100%"');
         $this->assertStringContainsString('var autosubmit = true;', $auto);
         $this->assertStringContainsString('if ( ! autosubmit || ! ev.persisted || reloadLaunched ) return;', $auto);
-        $this->assertMatchesRegularExpression('/reloadLaunched = false;.*?reloadLaunched = true;.*?tsugiLaunchForm\(\);/s', $auto);
+        $this->assertStringContainsString('if ( ! iframeIsBlank() ) return;', $auto);
+        $this->assertMatchesRegularExpression('/reloadLaunched = false;.*?if \( ! iframeIsBlank\(\) \) return;.*?reloadLaunched = true;.*?tsugiLaunchForm\(\);/s', $auto);
     }
 
     public function testPostLaunchHTMLWithEndform() {

--- a/lti/store/test.php
+++ b/lti/store/test.php
@@ -14,6 +14,7 @@ $LAUNCH = LTIX::requireData(LTIX::USER);
 
 $p = $CFG->dbprefix;
 
+$OUTPUT->noCacheHeader();
 $OUTPUT->header();
 ?>
     <style>

--- a/store/test.php
+++ b/store/test.php
@@ -15,6 +15,7 @@ session_start();
 $p = $CFG->dbprefix;
 LTIX::getConnection();
 
+$OUTPUT->noCacheHeader();
 $OUTPUT->header();
 ?>
 <style>


### PR DESCRIPTION
## Summary
- Browser reload of an LTI Try It (or other `postLaunchHTML` iframe) restores the iframe’s previous POST document; that restore fails and the frame stays blank, while a fresh GET of the same outer URL works.
- On reload, wait for `pageshow`, wipe the restored frame, and POST a new launch into `about:blank`. Launch errors are visible without the jQuery dialog, and the store test harness is not cached.

## Test plan
- [ ] Store Try It: launch a tool in the iframe, then Cmd-R and the toolbar reload — the tool should come back, not a blank frame.
- [ ] Enter in the location bar still launches as before.
- [ ] First load (not a reload) still auto-submits once.
- [ ] With debug launch enabled, the form is not auto-submitted.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Error messages and details are now safely escaped and displayed in a visible error container.
  - Improved iframe launch and reload handling to prevent duplicate submissions and stale content.
  - Manual launches now preserve the expected submit behavior without unintended automatic form preparation.
  - Added no-cache headers to test pages so refreshed content is reliably retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->