### PR TITLE
Add GIFT and QTI import and GIFT export to every Quiz1 quiz.

### DIFF
--- a/docs/quiz1.md
+++ b/docs/quiz1.md
@@ -92,7 +92,7 @@ the pattern-match profile. The stored Quiz1 type is unchanged.
 
 Instructors can import GIFT or QTI and export GIFT or QTI from the quiz list and from Edit. Import **appends** questions to that quiz. Bad or unsupported items are skipped with a warning; the rest still import. A partial quiz is the intended outcome.
 
-GIFT supports the six Quiz1 types except pattern match (exported as short answer; import becomes fill in the blank). Numerical and matching GIFT items are skipped. QTI import reads Common Cartridge 1.2.1 (including Quiz1’s own export) and Canvas `question_type` metadata. Zip / `.imscc` packages are accepted when they contain `questestinterop` XML.
+GIFT supports the six Quiz1 types except pattern match (exported as short answer; import becomes fill in the blank). Numerical and matching GIFT items are skipped. QTI import reads Common Cartridge 1.2.1 (including Quiz1’s own export) and Canvas `question_type` metadata. A zip of **quiz** files (sometimes named `.imscc`) is accepted when it contains `questestinterop` XML — this is not a course cartridge import. A zip is rejected (before any extract) if it lists more than 128 files or more than 8 MiB of declared uncompressed data; individual members over 5 MiB are skipped.
 
 ## Not in Phase 0
 

--- a/docs/quiz1.md
+++ b/docs/quiz1.md
@@ -90,7 +90,7 @@ the pattern-match profile. The stored Quiz1 type is unchanged.
 
 ## Import / export on every quiz
 
-Instructors can import GIFT or QTI and export GIFT or QTI from the quiz list and from Edit. Import **appends** questions to that quiz.
+Instructors can import GIFT or QTI and export GIFT or QTI from the quiz list and from Edit. Import **appends** questions to that quiz. Bad or unsupported items are skipped with a warning; the rest still import. A partial quiz is the intended outcome.
 
 GIFT supports the six Quiz1 types except pattern match (exported as short answer; import becomes fill in the blank). Numerical and matching GIFT items are skipped. QTI import reads Common Cartridge 1.2.1 (including Quiz1’s own export) and Canvas `question_type` metadata. Zip / `.imscc` packages are accepted when they contain `questestinterop` XML.
 

--- a/docs/quiz1.md
+++ b/docs/quiz1.md
@@ -5,10 +5,11 @@ Native Tsugi quiz authoring (Phase 0). This is **not** an LTI tool and is not th
 Pipeline:
 
 ```
-Quiz editor  →  semantic Quiz1 model  →  Qti12Exporter  →  Common Cartridge QTI 1.2.1 XML
+GIFT / QTI import  →  semantic Quiz1 model  →  GIFT / QTI export
+Quiz editor        →  semantic Quiz1 model  →  Qti12Exporter / GiftExporter
 ```
 
-QTI XML is an interchange format only. It is never stored as the database representation.
+QTI XML and GIFT are interchange formats only. They are never stored as the database representation.
 
 ## Data model
 
@@ -46,6 +47,8 @@ Deleting a quiz cascades to questions and answers (InnoDB FKs).
 | Persistence | `lib/src/Services/Quiz1/QuizRepository.php` |
 | Take scoring | `lib/src/Services/Quiz1/Grader.php` |
 | QTI 1.2.1 CC exporter | `lib/src/Services/Quiz1/Qti12Exporter.php` |
+| QTI 1.2.1 importer | `lib/src/Services/Quiz1/Qti12Importer.php` |
+| GIFT exporter / importer | `lib/src/Services/Quiz1/GiftExporter.php`, `GiftImporter.php` |
 | Sample / interoperability quiz | `lib/src/Services/Quiz1/SampleQuiz.php` |
 
 The exporter uses `DOMDocument`. The model does not know about XML.
@@ -65,6 +68,9 @@ Instructor-only authoring (same `requireInstructor` / CSRF patterns as Pages). T
 - `/quiz1/{id}/questions/add` — add a question
 - `/quiz1/{id}/questions/{qid}/edit`
 - `/quiz1/{id}/export` — download QTI XML
+- `/quiz1/{id}/export/gift` — download GIFT
+- `/quiz1/{id}/import/gift` — add GIFT questions to this quiz
+- `/quiz1/{id}/import/qti` — add QTI questions to this quiz
 - `POST /quiz1/sample` — create the six-type sample quiz
 
 ## Manual LMS interoperability test
@@ -82,9 +88,15 @@ Setup **Canvas** export writes those questions as `cc.fib.v0p1` so the warning
 does not appear. Matching becomes exact (not substring). Generic and Sakai keep
 the pattern-match profile. The stored Quiz1 type is unchanged.
 
+## Import / export on every quiz
+
+Instructors can import GIFT or QTI and export GIFT or QTI from the quiz list and from Edit. Import **appends** questions to that quiz.
+
+GIFT supports the six Quiz1 types except pattern match (exported as short answer; import becomes fill in the blank). Numerical and matching GIFT items are skipped. QTI import reads Common Cartridge 1.2.1 (including Quiz1’s own export) and Canvas `question_type` metadata. Zip / `.imscc` packages are accepted when they contain `questestinterop` XML.
+
 ## Not in Phase 0
 
-QTI import, GIFT import/export, Gift Quizzes migration, LTI, question banks, persisted attempts / gradebook.
+Gift Quizzes migration, LTI, question banks, persisted attempts / gradebook.
 
 **Take:** Logged-in users open `/quiz1/{id}` (Lessons uses this URL). Computer-scored questions are graded on submit; essays are not auto-scored. Attempts are not stored yet. Instructors get an **Edit quiz** button on the take page.
 
@@ -108,8 +120,6 @@ Legacy `/cc/export` is unchanged and still writes Canvas course_settings.
 Later:
 
 ```
-QTI import  →  Quiz1 model  →  QTI export
-GIFT import →  Quiz1 model  →  QTI export  (and later GIFT export)
 Persist attempts and send scores to the gradebook
 Export quizzes that are not referenced in lessons
 ```

--- a/lib/src/Controllers/Quiz1.php
+++ b/lib/src/Controllers/Quiz1.php
@@ -7,9 +7,13 @@ use Tsugi\Core\LTIX;
 use Tsugi\Lumen\Application;
 use Tsugi\Services\Quiz1\Answer;
 use Tsugi\Services\Quiz1\ExportException;
+use Tsugi\Services\Quiz1\GiftExporter;
+use Tsugi\Services\Quiz1\GiftImporter;
 use Tsugi\Services\Quiz1\Grader;
 use Tsugi\Services\Quiz1\Html;
+use Tsugi\Services\Quiz1\ImportException;
 use Tsugi\Services\Quiz1\Qti12Exporter;
+use Tsugi\Services\Quiz1\Qti12Importer;
 use Tsugi\Services\Quiz1\Question;
 use Tsugi\Services\Quiz1\QuestionTypes;
 use Tsugi\Services\Quiz1\Quiz;
@@ -52,6 +56,11 @@ class Quiz1 extends Tool {
         $app->router->post($prefix.'/add', 'Quiz1@addPost');
         $app->router->post($prefix.'/sample', 'Quiz1@samplePost');
         $app->router->get($prefix.'/{id}/export', 'Quiz1@export');
+        $app->router->get($prefix.'/{id}/export/gift', 'Quiz1@exportGift');
+        $app->router->get($prefix.'/{id}/import/gift', 'Quiz1@importGift');
+        $app->router->post($prefix.'/{id}/import/gift', 'Quiz1@importGiftPost');
+        $app->router->get($prefix.'/{id}/import/qti', 'Quiz1@importQti');
+        $app->router->post($prefix.'/{id}/import/qti', 'Quiz1@importQtiPost');
         $app->router->get($prefix.'/{id}/questions/add', 'Quiz1@questionAdd');
         $app->router->post($prefix.'/{id}/questions/add', 'Quiz1@questionAddPost');
         $app->router->get($prefix.'/{id}/questions/{qid}/edit', 'Quiz1@questionEdit');
@@ -91,7 +100,7 @@ class Quiz1 extends Tool {
                     <a href="<?= htmlspecialchars($home.'/add') ?>" class="btn btn-primary"><?= htmlspecialchars(__('New Quiz')) ?></a>
                 </span>
             </h1>
-            <p class="help-block"><?= htmlspecialchars(__('Create quizzes as course resources. Students take them from Lessons or from the Take link. Export as Common Cartridge QTI 1.2.1 from Setup or Export QTI.')) ?></p>
+            <p class="help-block"><?= htmlspecialchars(__('Create quizzes as course resources. Students take them from Lessons or from the Take link. Import or export GIFT and Common Cartridge QTI 1.2.1 on any quiz.')) ?></p>
             <?php if ( count($quizzes) < 1 ): ?>
                 <p><?= htmlspecialchars(__('No quizzes yet.')) ?></p>
                 <form method="post" action="<?= htmlspecialchars($home.'/sample') ?>">
@@ -115,7 +124,7 @@ class Quiz1 extends Tool {
                             <td class="text-right">
                                 <a class="btn btn-xs btn-primary" href="<?= htmlspecialchars($home.'/'.$quiz->id) ?>"><?= htmlspecialchars(__('Take')) ?></a>
                                 <a class="btn btn-xs btn-default" href="<?= htmlspecialchars($home.'/'.$quiz->id.'/edit') ?>"><?= htmlspecialchars(__('Edit')) ?></a>
-                                <a class="btn btn-xs btn-default" href="<?= htmlspecialchars($home.'/'.$quiz->id.'/export') ?>"><?= htmlspecialchars(__('Export QTI')) ?></a>
+                                <?= self::interchangeButtons($home, $quiz->id, true) ?>
                                 <form method="post" action="<?= htmlspecialchars($home.'/'.$quiz->id.'/delete') ?>" style="display:inline;" onsubmit="return confirm(<?= htmlspecialchars(json_encode(__('Delete this quiz and all of its questions?')), ENT_QUOTES) ?>);">
                                     <?= self::csrfField() ?>
                                     <button type="submit" class="btn btn-xs btn-danger"><?= htmlspecialchars(__('Delete')) ?></button>
@@ -484,6 +493,43 @@ class Quiz1 extends Tool {
         return $response;
     }
 
+    public function exportGift(Request $request, $id) {
+        $home = $this->toolHome(self::ROUTE);
+        $this->requireInstructor($home);
+        $quiz = QuizRepository::load((int) $id, U::currentContextId());
+        if ( ! $quiz ) {
+            U::flashError(__('Quiz not found.'));
+            return new RedirectResponse($home);
+        }
+        try {
+            $gift = GiftExporter::export($quiz);
+        } catch ( ExportException $e ) {
+            U::flashError($e->getMessage());
+            return new RedirectResponse($home.'/'.$id.'/edit');
+        }
+        $response = new Response($gift, 200, array(
+            'Content-Type' => 'text/plain; charset=UTF-8',
+            'Content-Disposition' => 'attachment; filename="'.$this->quizSlug($quiz).'.gift"',
+        ));
+        return $response;
+    }
+
+    public function importGift(Request $request, $id) {
+        return $this->renderImportForm((int) $id, 'gift');
+    }
+
+    public function importGiftPost(Request $request, $id) {
+        return $this->handleImportPost((int) $id, 'gift');
+    }
+
+    public function importQti(Request $request, $id) {
+        return $this->renderImportForm((int) $id, 'qti');
+    }
+
+    public function importQtiPost(Request $request, $id) {
+        return $this->handleImportPost((int) $id, 'qti');
+    }
+
     public function samplePost(Request $request) {
         $home = $this->toolHome(self::ROUTE);
         $this->requireInstructor($home);
@@ -503,8 +549,145 @@ class Quiz1 extends Tool {
         $quiz->context_id = U::currentContextId();
         $quiz->user_id = U::loggedInUserId();
         $id = QuizRepository::insertQuiz($quiz);
-        U::flashSuccess(__('Sample quiz created. Export QTI and import into an LMS to test interoperability.'));
+        U::flashSuccess(__('Sample quiz created. Export QTI or GIFT, or import more questions from GIFT or QTI.'));
         return new RedirectResponse($home.'/'.$id.'/edit');
+    }
+
+    /**
+     * Import / export actions available on every quiz.
+     */
+    private static function interchangeButtons($home, $quiz_id, $small) {
+        $cls = $small ? 'btn btn-xs btn-default' : 'btn btn-default';
+        $id = (int) $quiz_id;
+        ob_start();
+        ?>
+        <a class="<?= $cls ?>" href="<?= htmlspecialchars($home.'/'.$id.'/export') ?>"><?= htmlspecialchars(__('Export QTI')) ?></a>
+        <a class="<?= $cls ?>" href="<?= htmlspecialchars($home.'/'.$id.'/export/gift') ?>"><?= htmlspecialchars(__('Export GIFT')) ?></a>
+        <a class="<?= $cls ?>" href="<?= htmlspecialchars($home.'/'.$id.'/import/gift') ?>"><?= htmlspecialchars(__('Import GIFT')) ?></a>
+        <a class="<?= $cls ?>" href="<?= htmlspecialchars($home.'/'.$id.'/import/qti') ?>"><?= htmlspecialchars(__('Import QTI')) ?></a>
+        <?php
+        return trim(ob_get_clean());
+    }
+
+    private function quizSlug(Quiz $quiz) {
+        $slug = preg_replace('/[^a-z0-9]+/i', '-', strtolower($quiz->title));
+        $slug = trim($slug, '-');
+        if ( $slug === '' ) {
+            $slug = 'quiz-'.$quiz->id;
+        }
+        return $slug;
+    }
+
+    /**
+     * @param 'gift'|'qti' $format
+     */
+    private function renderImportForm($id, $format) {
+        global $OUTPUT;
+        $home = $this->toolHome(self::ROUTE);
+        $this->requireInstructor($home);
+        $quiz = QuizRepository::load((int) $id, U::currentContextId());
+        if ( ! $quiz ) {
+            U::flashError(__('Quiz not found.'));
+            return new RedirectResponse($home);
+        }
+
+        $is_gift = $format === 'gift';
+        $heading = $is_gift ? __('Import GIFT') : __('Import QTI');
+        $action = $home.'/'.$quiz->id.'/import/'.($is_gift ? 'gift' : 'qti');
+        $accept = $is_gift ? '.gift,.txt,text/plain' : '.xml,.zip,.imscc,application/xml,text/xml,application/zip';
+        $help = $is_gift
+            ? __('Paste Moodle GIFT or upload a .gift / .txt file. Questions are added to this quiz. Numerical and matching items are skipped.')
+            : __('Paste Common Cartridge QTI 1.2.1 XML or upload an .xml / .zip / .imscc file. Questions are added to this quiz.');
+
+        $OUTPUT->header();
+        $OUTPUT->bodyStart();
+        $OUTPUT->topNav();
+        $OUTPUT->flashMessages();
+        ?>
+        <main class="container" role="main" id="main-content">
+            <p><a href="<?= htmlspecialchars($home.'/'.$quiz->id.'/edit') ?>">&larr; <?= htmlspecialchars($quiz->title) ?></a></p>
+            <h1><?= htmlspecialchars($heading) ?></h1>
+            <p class="help-block"><?= htmlspecialchars($help) ?></p>
+            <form method="post" action="<?= htmlspecialchars($action) ?>" enctype="multipart/form-data">
+                <?= self::csrfField() ?>
+                <div class="form-group">
+                    <label for="file"><?= htmlspecialchars(__('File')) ?></label>
+                    <input type="file" id="file" name="file" accept="<?= htmlspecialchars($accept) ?>">
+                </div>
+                <div class="form-group">
+                    <label for="text"><?= htmlspecialchars($is_gift ? __('Or paste GIFT') : __('Or paste QTI XML')) ?></label>
+                    <textarea class="form-control" id="text" name="text" rows="16" style="font-family:monospace;"></textarea>
+                </div>
+                <p>
+                    <button type="submit" class="btn btn-primary"><?= htmlspecialchars(__('Import questions')) ?></button>
+                    <a class="btn btn-default" href="<?= htmlspecialchars($home.'/'.$quiz->id.'/edit') ?>"><?= htmlspecialchars(__('Cancel')) ?></a>
+                </p>
+            </form>
+        </main>
+        <?php
+        $OUTPUT->footer();
+        return '';
+    }
+
+    /**
+     * @param 'gift'|'qti' $format
+     */
+    private function handleImportPost($id, $format) {
+        $home = $this->toolHome(self::ROUTE);
+        $this->requireInstructor($home);
+        $csrf = self::requireCsrf($home.'/'.$id.'/import/'.$format);
+        if ( $csrf ) {
+            return $csrf;
+        }
+        $quiz = QuizRepository::load((int) $id, U::currentContextId());
+        if ( ! $quiz ) {
+            U::flashError(__('Quiz not found.'));
+            return new RedirectResponse($home);
+        }
+
+        try {
+            $payload = $this->readImportInput();
+            if ( $format === 'gift' ) {
+                list($imported, $warnings) = GiftImporter::import($payload);
+            } else {
+                list($imported, $warnings) = Qti12Importer::import($payload);
+            }
+        } catch ( ImportException $e ) {
+            U::flashError($e->getMessage());
+            return new RedirectResponse($home.'/'.$id.'/import/'.$format);
+        }
+
+        $n = QuizRepository::appendQuestions($quiz->id, $imported->questions);
+        if ( $n < 1 ) {
+            U::flashError(__('No questions were imported.'));
+            return new RedirectResponse($home.'/'.$id.'/import/'.$format);
+        }
+        U::flashSuccess(sprintf(__('Imported %d question(s).'), $n));
+        foreach ( $warnings as $warn ) {
+            U::flashError($warn);
+        }
+        return new RedirectResponse($home.'/'.$id.'/edit');
+    }
+
+    private function readImportInput() {
+        if ( ! empty($_FILES['file']['tmp_name']) && is_uploaded_file($_FILES['file']['tmp_name']) ) {
+            if ( (int) $_FILES['file']['error'] !== UPLOAD_ERR_OK ) {
+                throw new ImportException(__('File upload failed.'));
+            }
+            if ( (int) $_FILES['file']['size'] > 2 * 1024 * 1024 ) {
+                throw new ImportException(__('File is too large (2 MB maximum).'));
+            }
+            $bytes = file_get_contents($_FILES['file']['tmp_name']);
+            if ( $bytes === false || $bytes === '' ) {
+                throw new ImportException(__('The uploaded file is empty.'));
+            }
+            return $bytes;
+        }
+        $text = trim((string) U::get($_POST, 'text', ''));
+        if ( $text === '' ) {
+            throw new ImportException(__('Paste quiz text or choose a file.'));
+        }
+        return $text;
     }
 
     /**
@@ -729,7 +912,7 @@ class Quiz1 extends Tool {
             <h1><?= htmlspecialchars(__('Edit Quiz')) ?>
                 <span class="pull-right">
                     <a class="btn btn-primary" href="<?= htmlspecialchars($home.'/'.$quiz->id) ?>"><?= htmlspecialchars(__('Take quiz')) ?></a>
-                    <a class="btn btn-default" href="<?= htmlspecialchars($home.'/'.$quiz->id.'/export') ?>"><?= htmlspecialchars(__('Export QTI')) ?></a>
+                    <?= self::interchangeButtons($home, $quiz->id, false) ?>
                 </span>
             </h1>
             <form method="post" action="<?= htmlspecialchars($home.'/'.$quiz->id.'/edit') ?>" id="quiz_form">

--- a/lib/src/Controllers/Quiz1.php
+++ b/lib/src/Controllers/Quiz1.php
@@ -554,17 +554,32 @@ class Quiz1 extends Tool {
     }
 
     /**
-     * Import / export actions available on every quiz.
+     * Import / export menus available on every quiz.
      */
     private static function interchangeButtons($home, $quiz_id, $small) {
-        $cls = $small ? 'btn btn-xs btn-default' : 'btn btn-default';
+        $cls = $small ? 'btn btn-xs btn-default dropdown-toggle' : 'btn btn-default dropdown-toggle';
         $id = (int) $quiz_id;
+        $base = $home.'/'.$id;
         ob_start();
         ?>
-        <a class="<?= $cls ?>" href="<?= htmlspecialchars($home.'/'.$id.'/export') ?>"><?= htmlspecialchars(__('Export QTI')) ?></a>
-        <a class="<?= $cls ?>" href="<?= htmlspecialchars($home.'/'.$id.'/export/gift') ?>"><?= htmlspecialchars(__('Export GIFT')) ?></a>
-        <a class="<?= $cls ?>" href="<?= htmlspecialchars($home.'/'.$id.'/import/gift') ?>"><?= htmlspecialchars(__('Import GIFT')) ?></a>
-        <a class="<?= $cls ?>" href="<?= htmlspecialchars($home.'/'.$id.'/import/qti') ?>"><?= htmlspecialchars(__('Import QTI')) ?></a>
+        <div class="btn-group" style="display:inline-block;">
+            <button type="button" class="<?= $cls ?>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <?= htmlspecialchars(__('Export')) ?> <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-right">
+                <li><a href="<?= htmlspecialchars($base.'/export') ?>"><?= htmlspecialchars(__('QTI')) ?></a></li>
+                <li><a href="<?= htmlspecialchars($base.'/export/gift') ?>"><?= htmlspecialchars(__('GIFT')) ?></a></li>
+            </ul>
+        </div>
+        <div class="btn-group" style="display:inline-block;">
+            <button type="button" class="<?= $cls ?>" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <?= htmlspecialchars(__('Import')) ?> <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu dropdown-menu-right">
+                <li><a href="<?= htmlspecialchars($base.'/import/gift') ?>"><?= htmlspecialchars(__('GIFT')) ?></a></li>
+                <li><a href="<?= htmlspecialchars($base.'/import/qti') ?>"><?= htmlspecialchars(__('QTI')) ?></a></li>
+            </ul>
+        </div>
         <?php
         return trim(ob_get_clean());
     }

--- a/lib/src/Controllers/Quiz1.php
+++ b/lib/src/Controllers/Quiz1.php
@@ -612,7 +612,7 @@ class Quiz1 extends Tool {
         $accept = $is_gift ? '.gift,.txt,text/plain' : '.xml,.zip,.imscc,application/xml,text/xml,application/zip';
         $help = $is_gift
             ? __('Paste Moodle GIFT or upload a .gift / .txt file. Questions are added to this quiz. Numerical and matching items are skipped.')
-            : __('Paste Common Cartridge QTI 1.2.1 XML or upload an .xml / .zip / .imscc file. Questions are added to this quiz.');
+            : __('Paste Common Cartridge QTI 1.2.1 XML or upload a quiz .xml / .zip / .imscc. This adds questions to this quiz; it does not import a course.');
 
         $OUTPUT->header();
         $OUTPUT->bodyStart();

--- a/lib/src/Controllers/Quiz1.php
+++ b/lib/src/Controllers/Quiz1.php
@@ -668,18 +668,27 @@ class Quiz1 extends Tool {
                 list($imported, $warnings) = Qti12Importer::import($payload);
             }
         } catch ( ImportException $e ) {
-            U::flashError($e->getMessage());
+            U::flashError(htmlspecialchars($e->getMessage(), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
             return new RedirectResponse($home.'/'.$id.'/import/'.$format);
         }
 
-        $n = QuizRepository::appendQuestions($quiz->id, $imported->questions);
+        list($n, $save_errors) = QuizRepository::appendQuestions($quiz->id, $imported->questions);
+        $warnings = array_merge($warnings, $save_errors);
         if ( $n < 1 ) {
-            U::flashError(__('No questions were imported.'));
+            $msg = __('No questions were imported.');
+            if ( count($warnings) ) {
+                $msg .= ' ' . implode(' ', $warnings);
+            }
+            U::flashError(htmlspecialchars($msg, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
             return new RedirectResponse($home.'/'.$id.'/import/'.$format);
         }
         U::flashSuccess(sprintf(__('Imported %d question(s).'), $n));
-        foreach ( $warnings as $warn ) {
-            U::flashError($warn);
+        if ( count($warnings) ) {
+            $safe = array();
+            foreach ( $warnings as $warn ) {
+                $safe[] = htmlspecialchars($warn, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            }
+            U::flashError(implode('<br>', $safe));
         }
         return new RedirectResponse($home.'/'.$id.'/edit');
     }

--- a/lib/src/Services/Quiz1/GiftExporter.php
+++ b/lib/src/Services/Quiz1/GiftExporter.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tsugi\Services\Quiz1;
+
+/**
+ * Serialize a Quiz1 quiz as Moodle GIFT text.
+ *
+ * GIFT has no pattern-match profile. Those questions are written as short
+ * answer (fill in the blank) and come back as fill_blank on import.
+ */
+class GiftExporter {
+
+    /**
+     * @return string UTF-8 GIFT
+     * @throws ExportException
+     */
+    public static function export(Quiz $quiz) {
+        $errors = $quiz->validate();
+        if ( count($errors) > 0 ) {
+            throw new ExportException("Quiz is not valid for GIFT export:\n" . implode("\n", $errors));
+        }
+        if ( count($quiz->questions) < 1 ) {
+            throw new ExportException('A quiz must have at least one question to export.');
+        }
+
+        $out = array();
+        $title = trim(strip_tags($quiz->title));
+        if ( $title !== '' ) {
+            $out[] = '// ' . self::commentLine($title);
+        }
+        $out[] = '// Exported from Tsugi Quiz1';
+        $out[] = '';
+
+        foreach ( $quiz->orderedQuestions() as $question ) {
+            $out[] = self::question($question);
+            $out[] = '';
+        }
+
+        return implode("\n", $out);
+    }
+
+    private static function question(Question $question) {
+        $lines = array();
+        if ( $question->type === QuestionTypes::PATTERN_MATCH ) {
+            $lines[] = '// Pattern match (exported as GIFT short answer)';
+        }
+
+        $head = '';
+        $title = trim($question->title);
+        if ( $title !== '' ) {
+            $head .= '::' . self::escape($title) . '::';
+        }
+        $head .= self::promptText($question->prompt);
+
+        $body = $head . self::answerBlock($question);
+        if ( ! Question::isBlankHtml($question->feedback) ) {
+            $body .= '####' . self::promptText($question->feedback);
+        }
+        $lines[] = $body;
+        return implode("\n", $lines);
+    }
+
+    private static function promptText($prompt) {
+        $prompt = (string) $prompt;
+        if ( $prompt !== strip_tags($prompt) ) {
+            return '[html]' . self::escape($prompt);
+        }
+        return self::escape($prompt);
+    }
+
+    private static function answerBlock(Question $question) {
+        if ( $question->type === QuestionTypes::ESSAY ) {
+            return '{}';
+        }
+        if ( $question->type === QuestionTypes::TRUE_FALSE ) {
+            $true = true;
+            foreach ( $question->nonEmptyAnswers() as $ans ) {
+                $label = strtolower(trim(strip_tags($ans->text)));
+                if ( $label === 'true' ) {
+                    $true = $ans->correct ? true : false;
+                    break;
+                }
+            }
+            return $true ? '{T}' : '{F}';
+        }
+
+        $rows = array();
+        foreach ( $question->nonEmptyAnswers() as $ans ) {
+            $text = self::escape(self::plainOrHtml($ans->text));
+            $fb = '';
+            if ( ! Question::isBlankHtml($ans->feedback) ) {
+                $fb = '#' . self::escape(self::plainOrHtml($ans->feedback));
+            }
+            if ( $question->type === QuestionTypes::MULTIPLE_RESPONSE ) {
+                if ( $ans->correct ) {
+                    $rows[] = '~%100%' . $text . $fb;
+                } else {
+                    $rows[] = '~' . $text . $fb;
+                }
+            } else if ( QuestionTypes::usesAcceptedStrings($question->type) ) {
+                $rows[] = '=' . $text . $fb;
+            } else {
+                $rows[] = ($ans->correct ? '=' : '~') . $text . $fb;
+            }
+        }
+        return "{\n" . implode("\n", $rows) . "\n}";
+    }
+
+    private static function plainOrHtml($html) {
+        $html = (string) $html;
+        if ( $html !== strip_tags($html) ) {
+            return $html;
+        }
+        return html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    }
+
+    /**
+     * Escape GIFT control characters.
+     */
+    public static function escape($text) {
+        $text = (string) $text;
+        $text = str_replace('\\', '\\\\', $text);
+        $map = array(
+            '~' => '\\~',
+            '=' => '\\=',
+            '#' => '\\#',
+            '{' => '\\{',
+            '}' => '\\}',
+            ':' => '\\:',
+        );
+        return str_replace(array_keys($map), array_values($map), $text);
+    }
+
+    private static function commentLine($text) {
+        return str_replace(array("\r", "\n"), ' ', $text);
+    }
+}

--- a/lib/src/Services/Quiz1/GiftExporter.php
+++ b/lib/src/Services/Quiz1/GiftExporter.php
@@ -73,30 +73,22 @@ class GiftExporter {
             return '{}';
         }
         if ( $question->type === QuestionTypes::TRUE_FALSE ) {
-            $true = true;
-            foreach ( $question->nonEmptyAnswers() as $ans ) {
-                $label = strtolower(trim(strip_tags($ans->text)));
-                if ( $label === 'true' ) {
-                    $true = $ans->correct ? true : false;
-                    break;
-                }
-            }
-            return $true ? '{T}' : '{F}';
+            return self::trueFalseBlock($question);
         }
 
         $rows = array();
-        foreach ( $question->nonEmptyAnswers() as $ans ) {
+        $mr_weights = $question->type === QuestionTypes::MULTIPLE_RESPONSE
+            ? self::multipleResponseWeights($question)
+            : array();
+        foreach ( $question->nonEmptyAnswers() as $i => $ans ) {
             $text = self::escape(self::plainOrHtml($ans->text));
             $fb = '';
             if ( ! Question::isBlankHtml($ans->feedback) ) {
                 $fb = '#' . self::escape(self::plainOrHtml($ans->feedback));
             }
             if ( $question->type === QuestionTypes::MULTIPLE_RESPONSE ) {
-                if ( $ans->correct ) {
-                    $rows[] = '~%100%' . $text . $fb;
-                } else {
-                    $rows[] = '~' . $text . $fb;
-                }
+                $w = $mr_weights[$i] ?? 0;
+                $rows[] = '~%' . self::formatGiftWeight($w) . '%' . $text . $fb;
             } else if ( QuestionTypes::usesAcceptedStrings($question->type) ) {
                 $rows[] = '=' . $text . $fb;
             } else {
@@ -104,6 +96,79 @@ class GiftExporter {
             }
         }
         return "{\n" . implode("\n", $rows) . "\n}";
+    }
+
+    /**
+     * Moodle GIFT: {T#incorrect#correct} or {F#incorrect#correct}.
+     */
+    private static function trueFalseBlock(Question $question) {
+        $true = true;
+        $wrong_fb = '';
+        $right_fb = '';
+        foreach ( $question->nonEmptyAnswers() as $ans ) {
+            $label = strtolower(trim(strip_tags($ans->text)));
+            if ( $label === 'true' ) {
+                $true = $ans->correct ? true : false;
+            }
+            if ( $ans->correct ) {
+                $right_fb = $ans->feedback;
+            } else {
+                $wrong_fb = $ans->feedback;
+            }
+        }
+        $token = $true ? 'T' : 'F';
+        if ( Question::isBlankHtml($wrong_fb) && Question::isBlankHtml($right_fb) ) {
+            return '{'.$token.'}';
+        }
+        $out = '{'.$token.'#';
+        if ( ! Question::isBlankHtml($wrong_fb) ) {
+            $out .= self::escape(self::plainOrHtml($wrong_fb));
+        }
+        if ( ! Question::isBlankHtml($right_fb) ) {
+            $out .= '#' . self::escape(self::plainOrHtml($right_fb));
+        }
+        return $out.'}';
+    }
+
+    /**
+     * Positive weights on correct answers sum to 100. Each incorrect is -100
+     * so a wrong selection zeros the Moodle score (Quiz1 is all-or-nothing).
+     *
+     * @return array<int,float> index in nonEmptyAnswers() => weight
+     */
+    private static function multipleResponseWeights(Question $question) {
+        $answers = $question->nonEmptyAnswers();
+        $correct_n = 0;
+        foreach ( $answers as $ans ) {
+            if ( $ans->correct ) {
+                $correct_n++;
+            }
+        }
+        $weights = array();
+        $left = 100.0;
+        $seen_correct = 0;
+        foreach ( $answers as $i => $ans ) {
+            if ( ! $ans->correct ) {
+                $weights[$i] = -100.0;
+                continue;
+            }
+            $seen_correct++;
+            if ( $seen_correct === $correct_n ) {
+                $weights[$i] = $left;
+            } else {
+                $w = round(100.0 / $correct_n, 5);
+                $weights[$i] = $w;
+                $left -= $w;
+            }
+        }
+        return $weights;
+    }
+
+    private static function formatGiftWeight($weight) {
+        if ( abs($weight - round($weight)) < 0.00001 ) {
+            return (string) (int) round($weight);
+        }
+        return rtrim(rtrim(sprintf('%.5F', $weight), '0'), '.');
     }
 
     private static function plainOrHtml($html) {

--- a/lib/src/Services/Quiz1/GiftImporter.php
+++ b/lib/src/Services/Quiz1/GiftImporter.php
@@ -179,7 +179,8 @@ class GiftImporter {
                 $wrong_fb = self::promptFromGift($parts[0]);
                 $right_fb = self::promptFromGift($parts[1]);
             } else {
-                $right_fb = self::promptFromGift($fb);
+                // Moodle: a single # string is feedback for the incorrect choice.
+                $wrong_fb = self::promptFromGift($fb);
             }
         }
         $question->answers = array(

--- a/lib/src/Services/Quiz1/GiftImporter.php
+++ b/lib/src/Services/Quiz1/GiftImporter.php
@@ -1,0 +1,339 @@
+<?php
+
+namespace Tsugi\Services\Quiz1;
+
+/**
+ * Parse Moodle GIFT into a format-neutral Quiz1 quiz.
+ *
+ * Supported: multiple choice, multiple response, true/false, essay,
+ * and short answer (fill in the blank). Numerical and matching items
+ * are skipped with a warning. Pattern match is not a GIFT type.
+ */
+class GiftImporter {
+
+    /**
+     * @param string $text
+     * @return array{0: Quiz, 1: string[]}
+     * @throws ImportException
+     */
+    public static function import($text) {
+        $warnings = array();
+        $text = self::stripBom((string) $text);
+        if ( trim($text) === '' ) {
+            throw new ImportException('GIFT text is empty.');
+        }
+
+        $quiz = new Quiz();
+        $seq = 1;
+        foreach ( self::blocks($text) as $raw ) {
+            if ( preg_match('/^\$CATEGORY:/', trim($raw) ) ) {
+                continue;
+            }
+            try {
+                $question = self::parseQuestion($raw, $seq);
+            } catch ( ImportException $e ) {
+                $warnings[] = $e->getMessage();
+                continue;
+            }
+            $errors = $question->validate();
+            if ( count($errors) ) {
+                $label = $question->title !== '' ? $question->title : Html::excerpt($question->prompt, 40);
+                $warnings[] = ($label !== '' ? $label . ': ' : '') . implode(' ', $errors);
+                continue;
+            }
+            $question->sequence = $seq;
+            $quiz->questions[] = $question;
+            $seq++;
+        }
+
+        if ( count($quiz->questions) < 1 ) {
+            $extra = count($warnings) ? ' ' . implode(' ', $warnings) : '';
+            throw new ImportException('No supported GIFT questions were found.' . $extra);
+        }
+        return array($quiz, $warnings);
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function blocks($text) {
+        $text = str_replace("\r\n", "\n", $text);
+        $text = str_replace("\r", "\n", $text);
+        $blocks = array();
+        $cur = '';
+        foreach ( explode("\n", $text) as $line ) {
+            $line = rtrim($line);
+            if ( strpos($line, '//') === 0 ) {
+                continue;
+            }
+            if ( $line === '' ) {
+                if ( trim($cur) !== '' ) {
+                    $blocks[] = $cur;
+                    $cur = '';
+                }
+                continue;
+            }
+            $cur = $cur === '' ? $line : $cur . "\n" . $line;
+        }
+        if ( trim($cur) !== '' ) {
+            $blocks[] = $cur;
+        }
+        return $blocks;
+    }
+
+    /**
+     * @throws ImportException
+     */
+    private static function parseQuestion($raw, $seq) {
+        $title = '';
+        $rest = $raw;
+        if ( preg_match('/^::(.*?)::(.*)$/s', $raw, $m) ) {
+            $title = trim(self::unescape($m[1]));
+            $rest = $m[2];
+        }
+
+        $pair = self::lastBracePair($rest);
+        if ( $pair === null ) {
+            throw new ImportException('Question is missing {answers}: ' . self::snippet($raw));
+        }
+        list($spos, $epos) = $pair;
+        $prompt_raw = trim(substr($rest, 0, $spos));
+        $after = trim(substr($rest, $epos + 1));
+        $answer = trim(substr($rest, $spos + 1, $epos - $spos - 1));
+
+        $question = new Question();
+        $question->title = $title;
+        $question->prompt = self::promptFromGift($prompt_raw);
+        $question->points = 1;
+        $question->sequence = $seq;
+
+        if ( $after !== '' && strpos($after, '####') === 0 ) {
+            $question->feedback = self::promptFromGift(substr($after, 4));
+        }
+
+        $answer_one_line = trim(preg_replace('/\s+/', ' ', $answer));
+        if ( $answer_one_line === '' ) {
+            $question->type = QuestionTypes::ESSAY;
+            return $question;
+        }
+
+        if ( preg_match('/^(TRUE|FALSE|T|F)\b/i', $answer_one_line) ) {
+            return self::trueFalse($question, $answer_one_line);
+        }
+
+        if ( isset($answer_one_line[0]) && $answer_one_line[0] === '#' ) {
+            throw new ImportException('Numerical GIFT questions are not supported: ' . self::snippet($raw));
+        }
+        if ( strpos($answer, '->') !== false ) {
+            throw new ImportException('Matching GIFT questions are not supported: ' . self::snippet($raw));
+        }
+
+        $parsed = self::parseChoiceAnswers($answer);
+        if ( count($parsed) < 1 ) {
+            throw new ImportException('Could not read GIFT answers: ' . self::snippet($raw));
+        }
+
+        $correct = 0;
+        $incorrect = 0;
+        $seq_a = 1;
+        foreach ( $parsed as $row ) {
+            $question->answers[] = Answer::make($row['text'], $row['correct'], $seq_a, null, $row['feedback']);
+            if ( $row['correct'] ) {
+                $correct++;
+            } else {
+                $incorrect++;
+            }
+            $seq_a++;
+        }
+
+        if ( $correct < 1 ) {
+            throw new ImportException('GIFT question has no correct answer: ' . self::snippet($raw));
+        }
+        if ( $incorrect === 0 ) {
+            $question->type = QuestionTypes::FILL_BLANK;
+            $tail = trim(substr($rest, $epos + 1));
+            if ( $tail !== '' && strpos($tail, '####') !== 0 ) {
+                $question->prompt = self::promptFromGift(trim(substr($rest, 0, $spos)) . ' [_____] ' . $tail);
+            }
+        } else if ( $correct > 1 ) {
+            $question->type = QuestionTypes::MULTIPLE_RESPONSE;
+        } else {
+            $question->type = QuestionTypes::MULTIPLE_CHOICE;
+        }
+        return $question;
+    }
+
+    private static function trueFalse(Question $question, $answer) {
+        $question->type = QuestionTypes::TRUE_FALSE;
+        if ( ! preg_match('/^(TRUE|FALSE|T|F)\b\s*(?:#(.*))?$/is', trim($answer), $m) ) {
+            throw new ImportException('Could not read true/false answer: ' . $answer);
+        }
+        $token = strtoupper($m[1]);
+        $is_true = ($token === 'T' || $token === 'TRUE');
+        $fb = isset($m[2]) ? trim($m[2]) : '';
+        $wrong_fb = '';
+        $right_fb = '';
+        if ( $fb !== '' ) {
+            $parts = explode('#', $fb, 2);
+            if ( count($parts) === 2 ) {
+                $wrong_fb = self::promptFromGift($parts[0]);
+                $right_fb = self::promptFromGift($parts[1]);
+            } else {
+                $right_fb = self::promptFromGift($fb);
+            }
+        }
+        $question->answers = array(
+            Answer::make('True', $is_true, 1, null, $is_true ? $right_fb : $wrong_fb),
+            Answer::make('False', ! $is_true, 2, null, $is_true ? $wrong_fb : $right_fb),
+        );
+        return $question;
+    }
+
+    /**
+     * @return array<int, array{correct:bool,text:string,feedback:string}>
+     */
+    private static function parseChoiceAnswers($answer) {
+        $rows = array();
+        $marker = null;
+        $buf = '';
+        $len = strlen($answer);
+        for ( $i = 0; $i <= $len; $i++ ) {
+            $at_end = ($i === $len);
+            $ch = $at_end ? '' : $answer[$i];
+            $escaped = ! $at_end && self::isEscaped($answer, $i);
+            if ( $at_end || ( ! $escaped && ($ch === '=' || $ch === '~') ) ) {
+                if ( $marker !== null ) {
+                    $row = self::oneAnswer($marker, $buf);
+                    if ( $row !== null ) {
+                        $rows[] = $row;
+                    }
+                }
+                if ( $at_end ) {
+                    break;
+                }
+                $marker = $ch;
+                $buf = '';
+                continue;
+            }
+            $buf .= $ch;
+        }
+        return $rows;
+    }
+
+    /**
+     * @return array{correct:bool,text:string,feedback:string}|null
+     */
+    private static function oneAnswer($marker, $raw) {
+        $raw = trim($raw);
+        if ( $raw === '' ) {
+            return null;
+        }
+        $weight = null;
+        if ( preg_match('/^%(-?\d+(?:\.\d+)?)%(.*)$/s', $raw, $m) ) {
+            $weight = (float) $m[1];
+            $raw = $m[2];
+        }
+        $text = '';
+        $feedback = '';
+        $len = strlen($raw);
+        for ( $i = 0; $i < $len; $i++ ) {
+            $ch = $raw[$i];
+            if ( $ch === '#' && ! self::isEscaped($raw, $i) && $i > 0 && trim($text) !== '' ) {
+                $feedback = substr($raw, $i + 1);
+                break;
+            }
+            $text .= $ch;
+        }
+        $text = trim(self::unescape($text));
+        $feedback = trim(self::unescape($feedback));
+        if ( $text === '' ) {
+            return null;
+        }
+        $correct = ($marker === '=') || ($weight !== null && $weight > 0);
+        return array(
+            'correct' => $correct,
+            'text' => $text,
+            'feedback' => $feedback,
+        );
+    }
+
+    /**
+     * @return array{0:int,1:int}|null
+     */
+    private static function lastBracePair($text) {
+        $end = false;
+        $len = strlen($text);
+        for ( $i = $len - 1; $i >= 0; $i-- ) {
+            if ( $text[$i] !== '}' || self::isEscaped($text, $i) ) {
+                continue;
+            }
+            $end = $i;
+            $depth = 1;
+            for ( $j = $i - 1; $j >= 0; $j-- ) {
+                if ( self::isEscaped($text, $j) ) {
+                    continue;
+                }
+                if ( $text[$j] === '}' ) {
+                    $depth++;
+                } else if ( $text[$j] === '{' ) {
+                    $depth--;
+                    if ( $depth === 0 ) {
+                        return array($j, $end);
+                    }
+                }
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private static function promptFromGift($text) {
+        $text = trim((string) $text);
+        if ( stripos($text, '[html]') === 0 ) {
+            return Html::purify(self::unescape(trim(substr($text, 6))));
+        }
+        if ( preg_match('/^\[(markdown|plain)\]/i', $text) ) {
+            $text = preg_replace('/^\[(markdown|plain)\]/i', '', $text);
+            $text = trim($text);
+        }
+        return htmlspecialchars(self::unescape($text), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    }
+
+    public static function unescape($text) {
+        $text = (string) $text;
+        $out = '';
+        $len = strlen($text);
+        for ( $i = 0; $i < $len; $i++ ) {
+            if ( $text[$i] === '\\' && $i + 1 < $len ) {
+                $out .= $text[$i + 1];
+                $i++;
+                continue;
+            }
+            $out .= $text[$i];
+        }
+        return $out;
+    }
+
+    private static function isEscaped($s, $i) {
+        $n = 0;
+        for ( $j = $i - 1; $j >= 0 && $s[$j] === '\\'; $j-- ) {
+            $n++;
+        }
+        return ($n % 2) === 1;
+    }
+
+    private static function snippet($raw) {
+        $one = preg_replace('/\s+/', ' ', trim($raw));
+        if ( strlen($one) > 80 ) {
+            return substr($one, 0, 77) . '...';
+        }
+        return $one;
+    }
+
+    private static function stripBom($text) {
+        if ( strncmp($text, "\xEF\xBB\xBF", 3) === 0 ) {
+            return substr($text, 3);
+        }
+        return $text;
+    }
+}

--- a/lib/src/Services/Quiz1/ImportException.php
+++ b/lib/src/Services/Quiz1/ImportException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tsugi\Services\Quiz1;
+
+/**
+ * Thrown when GIFT or QTI cannot be turned into a Quiz1 quiz.
+ */
+class ImportException extends \RuntimeException {
+}

--- a/lib/src/Services/Quiz1/Qti12Importer.php
+++ b/lib/src/Services/Quiz1/Qti12Importer.php
@@ -1,0 +1,503 @@
+<?php
+
+namespace Tsugi\Services\Quiz1;
+
+/**
+ * Parse Common Cartridge QTI 1.2.1 (and close cousins) into a Quiz1 quiz.
+ *
+ * Prefers cc_profile, then Canvas question_type, then presentation shape.
+ * Zip / IMSCC payloads are accepted when they contain questestinterop XML.
+ */
+class Qti12Importer {
+
+    /**
+     * @param string $payload XML or zip bytes
+     * @return array{0: Quiz, 1: string[]}
+     * @throws ImportException
+     */
+    public static function import($payload) {
+        $warnings = array();
+        $xml = self::xmlFromPayload((string) $payload);
+        $prev = libxml_use_internal_errors(true);
+        $dom = new \DOMDocument();
+        $ok = $dom->loadXML($xml);
+        $errs = libxml_get_errors();
+        libxml_clear_errors();
+        libxml_use_internal_errors($prev);
+        if ( ! $ok ) {
+            $msg = 'QTI XML could not be parsed.';
+            if ( count($errs) ) {
+                $msg .= ' ' . trim($errs[0]->message);
+            }
+            throw new ImportException($msg);
+        }
+
+        $quiz = new Quiz();
+        $assessment = self::firstDescendant($dom->documentElement, 'assessment');
+        if ( $assessment ) {
+            $quiz->title = trim($assessment->getAttribute('title'));
+            $quiz->instructions = Html::purify(self::rubricText($assessment));
+        }
+
+        $seq = 1;
+        foreach ( $dom->getElementsByTagName('item') as $item ) {
+            if ( ! $item instanceof \DOMElement ) {
+                continue;
+            }
+            try {
+                $question = self::itemToQuestion($item, $seq);
+            } catch ( ImportException $e ) {
+                $warnings[] = $e->getMessage();
+                continue;
+            }
+            $errors = $question->validate();
+            if ( count($errors) ) {
+                $label = $question->title !== '' ? $question->title : Html::excerpt($question->prompt, 40);
+                $warnings[] = ($label !== '' ? $label . ': ' : '') . implode(' ', $errors);
+                continue;
+            }
+            $question->sequence = $seq;
+            $quiz->questions[] = $question;
+            $seq++;
+        }
+
+        if ( count($quiz->questions) < 1 ) {
+            $extra = count($warnings) ? ' ' . implode(' ', $warnings) : '';
+            throw new ImportException('No supported QTI questions were found.' . $extra);
+        }
+        return array($quiz, $warnings);
+    }
+
+    /**
+     * @throws ImportException
+     */
+    private static function xmlFromPayload($payload) {
+        $payload = self::stripBom($payload);
+        if ( strncmp($payload, 'PK', 2) === 0 ) {
+            return self::xmlFromZip($payload);
+        }
+        $trim = ltrim($payload);
+        if ( $trim !== '' && $trim[0] === '<' ) {
+            return $payload;
+        }
+        throw new ImportException('Import must be QTI XML or a zip/IMSCC file that contains QTI.');
+    }
+
+    /**
+     * @throws ImportException
+     */
+    private static function xmlFromZip($bytes) {
+        $tmp = tempnam(sys_get_temp_dir(), 'q1qti');
+        if ( $tmp === false ) {
+            throw new ImportException('Could not read the QTI zip file.');
+        }
+        file_put_contents($tmp, $bytes);
+        $zip = new \ZipArchive();
+        $opened = $zip->open($tmp);
+        if ( $opened !== true ) {
+            @unlink($tmp);
+            throw new ImportException('The zip/IMSCC file could not be opened.');
+        }
+        $found = null;
+        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+            $name = $zip->getNameIndex($i);
+            if ( ! is_string($name) || str_ends_with($name, '/') ) {
+                continue;
+            }
+            $content = $zip->getFromIndex($i);
+            if ( ! is_string($content) || strlen($content) < 20 || strlen($content) > 5 * 1024 * 1024 ) {
+                continue;
+            }
+            if ( stripos($content, 'questestinterop') !== false ) {
+                $found = $content;
+                break;
+            }
+        }
+        $zip->close();
+        @unlink($tmp);
+        if ( $found === null ) {
+            throw new ImportException('No QTI assessment XML was found in the zip file.');
+        }
+        return $found;
+    }
+
+    /**
+     * @throws ImportException
+     */
+    private static function itemToQuestion(\DOMElement $item, $seq) {
+        $meta = self::itemMeta($item);
+        $type = self::typeFromMetaAndItem($meta, $item);
+        if ( $type === null ) {
+            $title = trim($item->getAttribute('title'));
+            throw new ImportException('Unsupported QTI question type: ' . ($title !== '' ? $title : 'item'));
+        }
+
+        $q = new Question();
+        $q->sequence = $seq;
+        $q->type = $type;
+        $q->title = trim($item->getAttribute('title'));
+        $q->prompt = Html::purify(self::presentationPrompt($item));
+        $q->points = self::pointsFromMeta($meta);
+        $q->feedback = Html::purify(self::feedbackByIdent($item, 'general_fb'));
+
+        if ( $type === QuestionTypes::ESSAY ) {
+            $q->sample_solution = Html::purify(self::solutionText($item));
+            return $q;
+        }
+
+        if ( QuestionTypes::usesChoiceAnswers($type) ) {
+            $q->answers = self::choiceAnswers($item);
+            if ( $type === QuestionTypes::TRUE_FALSE ) {
+                $q->answers = self::normalizeTrueFalse($q->answers);
+            }
+            return $q;
+        }
+
+        $strings = self::stringAnswers($item);
+        $q->answers = $strings['answers'];
+        if ( $type === QuestionTypes::PATTERN_MATCH ) {
+            $q->case_sensitive = $strings['case_sensitive'];
+        }
+        return $q;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private static function itemMeta(\DOMElement $item) {
+        $out = array();
+        foreach ( $item->getElementsByTagName('qtimetadatafield') as $field ) {
+            if ( ! $field instanceof \DOMElement ) {
+                continue;
+            }
+            $label = self::firstDescendant($field, 'fieldlabel');
+            $entry = self::firstDescendant($field, 'fieldentry');
+            if ( $label && $entry ) {
+                $out[trim($label->textContent)] = trim($entry->textContent);
+            }
+        }
+        return $out;
+    }
+
+    /**
+     * @param array<string,string> $meta
+     */
+    private static function typeFromMetaAndItem(array $meta, \DOMElement $item) {
+        $profiles = array(
+            'cc.multiple_choice.v0p1' => QuestionTypes::MULTIPLE_CHOICE,
+            'cc.multiple_response.v0p1' => QuestionTypes::MULTIPLE_RESPONSE,
+            'cc.true_false.v0p1' => QuestionTypes::TRUE_FALSE,
+            'cc.essay.v0p1' => QuestionTypes::ESSAY,
+            'cc.fib.v0p1' => QuestionTypes::FILL_BLANK,
+            'cc.pattern_match.v0p1' => QuestionTypes::PATTERN_MATCH,
+        );
+        $profile = $meta['cc_profile'] ?? '';
+        if ( isset($profiles[$profile]) ) {
+            return $profiles[$profile];
+        }
+
+        $canvas = array(
+            'multiple_choice_question' => QuestionTypes::MULTIPLE_CHOICE,
+            'multiple_answers_question' => QuestionTypes::MULTIPLE_RESPONSE,
+            'true_false_question' => QuestionTypes::TRUE_FALSE,
+            'essay_question' => QuestionTypes::ESSAY,
+            'short_answer_question' => QuestionTypes::FILL_BLANK,
+        );
+        $qt = $meta['question_type'] ?? '';
+        if ( isset($canvas[$qt]) ) {
+            return $canvas[$qt];
+        }
+
+        return self::inferType($item, $meta);
+    }
+
+    /**
+     * @param array<string,string> $meta
+     */
+    private static function inferType(\DOMElement $item, array $meta) {
+        $pres = self::firstChild($item, 'presentation');
+        if ( ! $pres ) {
+            return null;
+        }
+        $lid = self::firstDescendant($pres, 'response_lid');
+        if ( $lid ) {
+            $labels = self::choiceLabels($pres);
+            if ( self::labelsLookTrueFalse($labels) ) {
+                return QuestionTypes::TRUE_FALSE;
+            }
+            $card = strtolower($lid->getAttribute('rcardinality'));
+            return $card === 'multiple' ? QuestionTypes::MULTIPLE_RESPONSE : QuestionTypes::MULTIPLE_CHOICE;
+        }
+        $str = self::firstDescendant($pres, 'response_str');
+        if ( $str ) {
+            $computer = strtolower($meta['qmd_computerscored'] ?? '');
+            if ( $computer === 'no' || self::firstChild($item, 'resprocessing') === null ) {
+                return QuestionTypes::ESSAY;
+            }
+            if ( $item->getElementsByTagName('varsubstring')->length > 0 ) {
+                return QuestionTypes::PATTERN_MATCH;
+            }
+            return QuestionTypes::FILL_BLANK;
+        }
+        return null;
+    }
+
+    /**
+     * @param array<string,string> $meta
+     */
+    private static function pointsFromMeta(array $meta) {
+        $raw = $meta['cc_weighting'] ?? $meta['points_possible'] ?? '1';
+        $n = (int) round((float) $raw);
+        if ( $n < 1 ) {
+            $n = 1;
+        }
+        if ( $n > 99 ) {
+            $n = 99;
+        }
+        return $n;
+    }
+
+    private static function presentationPrompt(\DOMElement $item) {
+        $pres = self::firstChild($item, 'presentation');
+        if ( ! $pres ) {
+            return '';
+        }
+        $material = self::firstChild($pres, 'material');
+        if ( ! $material ) {
+            return '';
+        }
+        $mat = self::firstChild($material, 'mattext');
+        return $mat ? $mat->textContent : '';
+    }
+
+    /**
+     * @return Answer[]
+     */
+    private static function choiceAnswers(\DOMElement $item) {
+        $pres = self::firstChild($item, 'presentation');
+        $labels = $pres ? self::choiceLabels($pres) : array();
+        $correct = self::correctChoiceIdents($item);
+        $answers = array();
+        $seq = 1;
+        foreach ( $labels as $ident => $text ) {
+            $answers[] = Answer::make(
+                Html::purify($text),
+                isset($correct[$ident]),
+                $seq
+            );
+            $seq++;
+        }
+        return $answers;
+    }
+
+    /**
+     * @return array<string,string> ident => text
+     */
+    private static function choiceLabels(\DOMElement $pres) {
+        $out = array();
+        foreach ( $pres->getElementsByTagName('response_label') as $label ) {
+            if ( ! $label instanceof \DOMElement ) {
+                continue;
+            }
+            $ident = $label->getAttribute('ident');
+            if ( $ident === '' ) {
+                continue;
+            }
+            $mat = self::firstDescendant($label, 'mattext');
+            $out[$ident] = $mat ? $mat->textContent : $ident;
+        }
+        return $out;
+    }
+
+    /**
+     * @param array<string,string> $labels
+     */
+    private static function labelsLookTrueFalse(array $labels) {
+        if ( count($labels) !== 2 ) {
+            return false;
+        }
+        $seen = array();
+        foreach ( $labels as $text ) {
+            $seen[] = strtolower(trim(strip_tags($text)));
+        }
+        sort($seen);
+        return $seen === array('false', 'true');
+    }
+
+    /**
+     * @return array<string,true>
+     */
+    private static function correctChoiceIdents(\DOMElement $item) {
+        $correct = array();
+        foreach ( self::scoringConditions($item) as $cond ) {
+            foreach ( $cond->getElementsByTagName('varequal') as $ve ) {
+                if ( ! $ve instanceof \DOMElement ) {
+                    continue;
+                }
+                if ( self::hasAncestorLocal($ve, 'not', $cond) ) {
+                    continue;
+                }
+                $ident = trim($ve->textContent);
+                if ( $ident !== '' ) {
+                    $correct[$ident] = true;
+                }
+            }
+        }
+        return $correct;
+    }
+
+    /**
+     * @return array{answers: Answer[], case_sensitive: bool}
+     */
+    private static function stringAnswers(\DOMElement $item) {
+        $answers = array();
+        $seq = 1;
+        $case_sensitive = false;
+        foreach ( self::scoringConditions($item) as $cond ) {
+            foreach ( $cond->getElementsByTagName('varequal') as $ve ) {
+                if ( ! $ve instanceof \DOMElement ) {
+                    continue;
+                }
+                $text = trim($ve->textContent);
+                if ( $text === '' ) {
+                    continue;
+                }
+                $answers[] = Answer::make($text, true, $seq);
+                $seq++;
+            }
+            foreach ( $cond->getElementsByTagName('varsubstring') as $vs ) {
+                if ( ! $vs instanceof \DOMElement ) {
+                    continue;
+                }
+                $text = trim($vs->textContent);
+                if ( $text === '' ) {
+                    continue;
+                }
+                if ( strtolower($vs->getAttribute('case')) === 'yes' ) {
+                    $case_sensitive = true;
+                }
+                $answers[] = Answer::make($text, true, $seq);
+                $seq++;
+            }
+        }
+        return array('answers' => $answers, 'case_sensitive' => $case_sensitive);
+    }
+
+    /**
+     * @return \DOMElement[]
+     */
+    private static function scoringConditions(\DOMElement $item) {
+        $rp = self::firstChild($item, 'resprocessing');
+        if ( ! $rp ) {
+            return array();
+        }
+        $all = array();
+        foreach ( $rp->childNodes as $child ) {
+            if ( $child instanceof \DOMElement && $child->localName === 'respcondition' ) {
+                $all[] = $child;
+            }
+        }
+        $scoring = array();
+        foreach ( $all as $cond ) {
+            if ( $cond->getAttribute('continue') === 'No' || $cond->getElementsByTagName('setvar')->length > 0 ) {
+                $scoring[] = $cond;
+            }
+        }
+        return count($scoring) ? $scoring : $all;
+    }
+
+    /**
+     * @param Answer[] $answers
+     * @return Answer[]
+     */
+    private static function normalizeTrueFalse(array $answers) {
+        $true = null;
+        $false = null;
+        foreach ( $answers as $ans ) {
+            $label = strtolower(trim(strip_tags($ans->text)));
+            if ( $label === 'true' ) {
+                $true = $ans;
+            } else if ( $label === 'false' ) {
+                $false = $ans;
+            }
+        }
+        if ( $true && $false ) {
+            $true->text = 'True';
+            $false->text = 'False';
+            $true->sequence = 1;
+            $false->sequence = 2;
+            return array($true, $false);
+        }
+        return $answers;
+    }
+
+    private static function solutionText(\DOMElement $item) {
+        foreach ( $item->getElementsByTagName('itemfeedback') as $fb ) {
+            if ( ! $fb instanceof \DOMElement ) {
+                continue;
+            }
+            if ( $fb->getAttribute('ident') === 'solution' || self::firstChild($fb, 'solution') ) {
+                $mat = self::firstDescendant($fb, 'mattext');
+                return $mat ? $mat->textContent : '';
+            }
+        }
+        return '';
+    }
+
+    private static function feedbackByIdent(\DOMElement $item, $ident) {
+        foreach ( $item->getElementsByTagName('itemfeedback') as $fb ) {
+            if ( $fb instanceof \DOMElement && $fb->getAttribute('ident') === $ident ) {
+                $mat = self::firstDescendant($fb, 'mattext');
+                return $mat ? $mat->textContent : '';
+            }
+        }
+        return '';
+    }
+
+    private static function rubricText(\DOMElement $assessment) {
+        $rubric = self::firstChild($assessment, 'rubric');
+        if ( ! $rubric ) {
+            return '';
+        }
+        $mat = self::firstDescendant($rubric, 'mattext');
+        return $mat ? $mat->textContent : '';
+    }
+
+    private static function firstChild(\DOMNode $node, $local) {
+        foreach ( $node->childNodes as $child ) {
+            if ( $child instanceof \DOMElement && $child->localName === $local ) {
+                return $child;
+            }
+        }
+        return null;
+    }
+
+    private static function firstDescendant(\DOMNode $node, $local) {
+        if ( $node instanceof \DOMDocument ) {
+            $node = $node->documentElement;
+        }
+        if ( ! $node instanceof \DOMElement ) {
+            return null;
+        }
+        $list = $node->getElementsByTagName($local);
+        return $list->length ? $list->item(0) : null;
+    }
+
+    private static function hasAncestorLocal(\DOMNode $node, $local, \DOMNode $stop) {
+        $cur = $node->parentNode;
+        while ( $cur && $cur !== $stop ) {
+            if ( $cur instanceof \DOMElement && $cur->localName === $local ) {
+                return true;
+            }
+            $cur = $cur->parentNode;
+        }
+        return false;
+    }
+
+    private static function stripBom($text) {
+        if ( strncmp($text, "\xEF\xBB\xBF", 3) === 0 ) {
+            return substr($text, 3);
+        }
+        return $text;
+    }
+}

--- a/lib/src/Services/Quiz1/Qti12Importer.php
+++ b/lib/src/Services/Quiz1/Qti12Importer.php
@@ -6,9 +6,19 @@ namespace Tsugi\Services\Quiz1;
  * Parse Common Cartridge QTI 1.2.1 (and close cousins) into a Quiz1 quiz.
  *
  * Prefers cc_profile, then Canvas question_type, then presentation shape.
- * Zip / IMSCC payloads are accepted when they contain questestinterop XML.
+ * A zip of quiz files (sometimes named .imscc) is accepted when it
+ * contains questestinterop XML. This is not a course cartridge import.
  */
 class Qti12Importer {
+
+    /** Refuse a zip that lists more files than this (stat only; no extract). */
+    const MAX_ZIP_ENTRIES = 128;
+
+    /** Refuse a zip whose declared uncompressed file sizes sum past this. */
+    const MAX_ZIP_UNCOMPRESSED = 8 * 1024 * 1024;
+
+    /** Skip one zip member larger than this (also the extract cap). */
+    const MAX_ZIP_ENTRY = 5 * 1024 * 1024;
 
     /**
      * @param string $payload XML or zip bytes
@@ -80,7 +90,7 @@ class Qti12Importer {
         if ( $trim !== '' && $trim[0] === '<' ) {
             return $payload;
         }
-        throw new ImportException('Import must be QTI XML or a zip/IMSCC file that contains QTI.');
+        throw new ImportException('Import must be QTI XML or a zip of quiz files that contains QTI.');
     }
 
     /**
@@ -96,8 +106,28 @@ class Qti12Importer {
         $opened = $zip->open($tmp);
         if ( $opened !== true ) {
             @unlink($tmp);
-            throw new ImportException('The zip/IMSCC file could not be opened.');
+            throw new ImportException('The quiz zip file could not be opened.');
         }
+        $fileCount = 0;
+        $declared = 0;
+        for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+            $name = $zip->getNameIndex($i);
+            if ( ! is_string($name) || str_ends_with($name, '/') ) {
+                continue;
+            }
+            $stat = $zip->statIndex($i);
+            if ( ! is_array($stat) ) {
+                continue;
+            }
+            $fileCount++;
+            $declared += isset($stat['size']) ? (int) $stat['size'] : 0;
+            if ( $fileCount > self::MAX_ZIP_ENTRIES || $declared > self::MAX_ZIP_UNCOMPRESSED ) {
+                $zip->close();
+                @unlink($tmp);
+                throw new ImportException('The zip file is too large to import (too many files or too much uncompressed data).');
+            }
+        }
+
         $found = null;
         for ( $i = 0; $i < $zip->numFiles; $i++ ) {
             $name = $zip->getNameIndex($i);
@@ -109,11 +139,11 @@ class Qti12Importer {
                 continue;
             }
             $size = isset($stat['size']) ? (int) $stat['size'] : 0;
-            if ( $size < 20 || $size > 5 * 1024 * 1024 ) {
+            if ( $size < 20 || $size > self::MAX_ZIP_ENTRY ) {
                 continue;
             }
             $content = $zip->getFromIndex($i);
-            if ( ! is_string($content) || strlen($content) < 20 || strlen($content) > 5 * 1024 * 1024 ) {
+            if ( ! is_string($content) || strlen($content) < 20 || strlen($content) > self::MAX_ZIP_ENTRY ) {
                 continue;
             }
             if ( stripos($content, 'questestinterop') !== false ) {

--- a/lib/src/Services/Quiz1/Qti12Importer.php
+++ b/lib/src/Services/Quiz1/Qti12Importer.php
@@ -104,6 +104,14 @@ class Qti12Importer {
             if ( ! is_string($name) || str_ends_with($name, '/') ) {
                 continue;
             }
+            $stat = $zip->statIndex($i);
+            if ( ! is_array($stat) ) {
+                continue;
+            }
+            $size = isset($stat['size']) ? (int) $stat['size'] : 0;
+            if ( $size < 20 || $size > 5 * 1024 * 1024 ) {
+                continue;
+            }
             $content = $zip->getFromIndex($i);
             if ( ! is_string($content) || strlen($content) < 20 || strlen($content) > 5 * 1024 * 1024 ) {
                 continue;
@@ -399,11 +407,38 @@ class Qti12Importer {
         }
         $scoring = array();
         foreach ( $all as $cond ) {
-            if ( $cond->getAttribute('continue') === 'No' || $cond->getElementsByTagName('setvar')->length > 0 ) {
+            $setvars = $cond->getElementsByTagName('setvar');
+            if ( $setvars->length > 0 ) {
+                if ( self::isPositiveScoring($cond) ) {
+                    $scoring[] = $cond;
+                }
+                continue;
+            }
+            if ( $cond->getAttribute('continue') === 'No' ) {
                 $scoring[] = $cond;
             }
         }
-        return count($scoring) ? $scoring : $all;
+        return $scoring;
+    }
+
+    /**
+     * True when a respcondition awards a positive SCORE (Set/Add above zero).
+     */
+    private static function isPositiveScoring(\DOMElement $cond) {
+        foreach ( $cond->getElementsByTagName('setvar') as $sv ) {
+            if ( ! $sv instanceof \DOMElement ) {
+                continue;
+            }
+            $action = strtolower($sv->getAttribute('action'));
+            $n = (float) trim($sv->textContent);
+            if ( $n <= 0 ) {
+                continue;
+            }
+            if ( $action === 'set' || $action === 'add' || $action === '' ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/lib/src/Services/Quiz1/QuizRepository.php
+++ b/lib/src/Services/Quiz1/QuizRepository.php
@@ -204,12 +204,20 @@ class QuizRepository {
     /**
      * Append questions to an existing quiz (sequence continues after the last item).
      *
+     * Best-effort: a failure on one question is recorded and the rest still
+     * save. A partial quiz is the intended outcome, not a rollback.
+     *
      * @param Question[] $questions
-     * @return int Number of questions inserted
+     * @return array{0: int, 1: string[]} Inserted count and per-question errors
      */
     public static function appendQuestions($quiz_id, array $questions) {
         $n = 0;
-        foreach ( $questions as $question ) {
+        $errors = array();
+        // Do not wrap this loop in a transaction. Import is liberal: keep
+        // every question that saves, record the ones that do not, and leave
+        // a partial quiz. Rolling back the whole file because one item failed
+        // would discard work the instructor can already use and edit.
+        foreach ( $questions as $i => $question ) {
             if ( ! $question instanceof Question ) {
                 continue;
             }
@@ -219,10 +227,18 @@ class QuizRepository {
             foreach ( $question->answers as $ans ) {
                 $ans->id = null;
             }
-            self::insertQuestion($question);
-            $n++;
+            try {
+                self::insertQuestion($question);
+                $n++;
+            } catch ( \Exception $e ) {
+                $label = $question->title !== '' ? $question->title : Html::excerpt($question->prompt, 40);
+                if ( $label === '' ) {
+                    $label = 'Question ' . ((int) $i + 1);
+                }
+                $errors[] = $label . ': ' . $e->getMessage();
+            }
         }
-        return $n;
+        return array($n, $errors);
     }
 
     public static function insertQuestion(Question $question) {

--- a/lib/src/Services/Quiz1/QuizRepository.php
+++ b/lib/src/Services/Quiz1/QuizRepository.php
@@ -201,6 +201,30 @@ class QuizRepository {
         );
     }
 
+    /**
+     * Append questions to an existing quiz (sequence continues after the last item).
+     *
+     * @param Question[] $questions
+     * @return int Number of questions inserted
+     */
+    public static function appendQuestions($quiz_id, array $questions) {
+        $n = 0;
+        foreach ( $questions as $question ) {
+            if ( ! $question instanceof Question ) {
+                continue;
+            }
+            $question->id = null;
+            $question->quiz_id = (int) $quiz_id;
+            $question->sequence = 0;
+            foreach ( $question->answers as $ans ) {
+                $ans->id = null;
+            }
+            self::insertQuestion($question);
+            $n++;
+        }
+        return $n;
+    }
+
     public static function insertQuestion(Question $question) {
         global $CFG, $PDOX;
         LTIX::getConnection();

--- a/lib/tests/Services/Quiz1/GiftRoundTripTest.php
+++ b/lib/tests/Services/Quiz1/GiftRoundTripTest.php
@@ -1,0 +1,124 @@
+<?php
+
+use Tsugi\Services\Quiz1\ExportException;
+use Tsugi\Services\Quiz1\GiftExporter;
+use Tsugi\Services\Quiz1\GiftImporter;
+use Tsugi\Services\Quiz1\ImportException;
+use Tsugi\Services\Quiz1\QuestionTypes;
+use Tsugi\Services\Quiz1\SampleQuiz;
+
+class GiftRoundTripTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSampleExportContainsAllTypes() {
+        $gift = GiftExporter::export(SampleQuiz::build(1));
+        $this->assertStringContainsString('HTTP protocol', $gift);
+        $this->assertStringContainsString('=HTTP', $gift);
+        $this->assertStringContainsString('~FTP', $gift);
+        $this->assertStringContainsString('~%100%GET', $gift);
+        $this->assertStringContainsString('{F}', $gift);
+        $this->assertStringContainsString('Explain REST', $gift);
+        $this->assertStringContainsString('{}', $gift);
+        $this->assertStringContainsString('=80', $gift);
+        $this->assertStringContainsString('=eighty', $gift);
+        $this->assertStringContainsString('Pattern match', $gift);
+        $this->assertStringContainsString('=Script', $gift);
+    }
+
+    public function testSampleRoundTripMapsPatternMatchToFillBlank() {
+        $gift = GiftExporter::export(SampleQuiz::build(1));
+        list($quiz, $warnings) = GiftImporter::import($gift);
+        $this->assertSame(array(), $warnings);
+        $this->assertCount(6, $quiz->questions);
+
+        $types = array();
+        foreach ( $quiz->orderedQuestions() as $q ) {
+            $types[] = $q->type;
+        }
+        $this->assertSame(
+            array(
+                QuestionTypes::MULTIPLE_CHOICE,
+                QuestionTypes::MULTIPLE_RESPONSE,
+                QuestionTypes::TRUE_FALSE,
+                QuestionTypes::ESSAY,
+                QuestionTypes::FILL_BLANK,
+                QuestionTypes::FILL_BLANK,
+            ),
+            $types
+        );
+
+        $mc = $quiz->questions[0];
+        $this->assertSame('HTTP protocol', $mc->title);
+        $this->assertStringContainsString('Which protocol', $mc->prompt);
+        $this->assertTrue($mc->answers[0]->correct);
+        $this->assertSame('HTTP', strip_tags($mc->answers[0]->text));
+        $this->assertFalse($mc->answers[1]->correct);
+
+        $mr = $quiz->questions[1];
+        $correct = array();
+        foreach ( $mr->answers as $ans ) {
+            if ( $ans->correct ) {
+                $correct[] = strip_tags($ans->text);
+            }
+        }
+        $this->assertSame(array('GET', 'POST'), $correct);
+
+        $tf = $quiz->questions[2];
+        $this->assertFalse($tf->answers[0]->correct);
+        $this->assertTrue($tf->answers[1]->correct);
+
+        $this->assertSame(QuestionTypes::ESSAY, $quiz->questions[3]->type);
+        $this->assertCount(0, $quiz->questions[3]->answers);
+
+        $fib = $quiz->questions[4];
+        $this->assertSame(array('80', 'eighty'), array(
+            strip_tags($fib->answers[0]->text),
+            strip_tags($fib->answers[1]->text),
+        ));
+    }
+
+    public function testPlainGiftWithoutTitles() {
+        $text = "What is 2+2? {=4 ~3 ~5}\n\nIs the sky blue? {T}\n";
+        list($quiz, $warnings) = GiftImporter::import($text);
+        $this->assertSame(array(), $warnings);
+        $this->assertCount(2, $quiz->questions);
+        $this->assertSame(QuestionTypes::MULTIPLE_CHOICE, $quiz->questions[0]->type);
+        $this->assertSame('4', $quiz->questions[0]->answers[0]->text);
+        $this->assertSame(QuestionTypes::TRUE_FALSE, $quiz->questions[1]->type);
+        $this->assertTrue($quiz->questions[1]->answers[0]->correct);
+    }
+
+    public function testShortAnswerBecomesFillBlank() {
+        $text = '::Port:: The default HTTP port is {=80 =eighty}';
+        list($quiz, $warnings) = GiftImporter::import($text);
+        $this->assertSame(array(), $warnings);
+        $this->assertSame(QuestionTypes::FILL_BLANK, $quiz->questions[0]->type);
+        $this->assertCount(2, $quiz->questions[0]->answers);
+    }
+
+    public function testNumericalIsSkippedWithWarning() {
+        $text = "::Num:: How many? {#3:2}\n\n::OK:: Pick {=yes ~no}\n";
+        list($quiz, $warnings) = GiftImporter::import($text);
+        $this->assertCount(1, $quiz->questions);
+        $this->assertNotEmpty($warnings);
+        $this->assertStringContainsString('Numerical', $warnings[0]);
+    }
+
+    public function testEmptyGiftThrows() {
+        $this->expectException(ImportException::class);
+        GiftImporter::import('   ');
+    }
+
+    public function testEmptyQuizRefusesExport() {
+        $quiz = new \Tsugi\Services\Quiz1\Quiz();
+        $quiz->title = 'Empty';
+        $this->expectException(ExportException::class);
+        GiftExporter::export($quiz);
+    }
+
+    public function testHtmlAndSpecialCharactersRoundTrip() {
+        $gift = GiftExporter::export(SampleQuiz::build(1));
+        list($quiz,) = GiftImporter::import($gift);
+        $this->assertStringContainsString('<strong>all</strong>', $quiz->questions[1]->prompt);
+        $this->assertStringContainsString('2 &lt; 3', $quiz->questions[0]->prompt);
+    }
+}

--- a/lib/tests/Services/Quiz1/GiftRoundTripTest.php
+++ b/lib/tests/Services/Quiz1/GiftRoundTripTest.php
@@ -14,7 +14,9 @@ class GiftRoundTripTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('HTTP protocol', $gift);
         $this->assertStringContainsString('=HTTP', $gift);
         $this->assertStringContainsString('~FTP', $gift);
-        $this->assertStringContainsString('~%100%GET', $gift);
+        $this->assertStringContainsString('~%50%GET', $gift);
+        $this->assertStringContainsString('~%50%POST', $gift);
+        $this->assertStringContainsString('~%-100%HTML', $gift);
         $this->assertStringContainsString('{F}', $gift);
         $this->assertStringContainsString('Explain REST', $gift);
         $this->assertStringContainsString('{}', $gift);
@@ -120,5 +122,45 @@ class GiftRoundTripTest extends \PHPUnit\Framework\TestCase
         list($quiz,) = GiftImporter::import($gift);
         $this->assertStringContainsString('<strong>all</strong>', $quiz->questions[1]->prompt);
         $this->assertStringContainsString('2 &lt; 3', $quiz->questions[0]->prompt);
+    }
+
+    public function testTrueFalseFeedbackRoundTrip() {
+        $quiz = new \Tsugi\Services\Quiz1\Quiz();
+        $quiz->title = 'TF feedback';
+        $q = new \Tsugi\Services\Quiz1\Question();
+        $q->sequence = 1;
+        $q->type = QuestionTypes::TRUE_FALSE;
+        $q->prompt = 'HTML is a programming language.';
+        $q->points = 1;
+        $q->answers = array(
+            \Tsugi\Services\Quiz1\Answer::make('True', false, 1, null, 'No, it is markup.'),
+            \Tsugi\Services\Quiz1\Answer::make('False', true, 2, null, 'Correct.'),
+        );
+        $quiz->questions[] = $q;
+
+        $gift = GiftExporter::export($quiz);
+        $this->assertStringContainsString('{F#No, it is markup.#Correct.}', $gift);
+
+        list($imported, $warnings) = GiftImporter::import($gift);
+        $this->assertSame(array(), $warnings);
+        $tf = $imported->questions[0];
+        $this->assertFalse($tf->answers[0]->correct);
+        $this->assertStringContainsString('No, it is markup.', $tf->answers[0]->feedback);
+        $this->assertTrue($tf->answers[1]->correct);
+        $this->assertStringContainsString('Correct.', $tf->answers[1]->feedback);
+    }
+
+    public function testMultipleResponseWeightsSumTo100() {
+        $quiz = SampleQuiz::buildMultipleResponse(1);
+        $gift = GiftExporter::export($quiz);
+        preg_match_all('/%(-?[\d.]+)%/', $gift, $m);
+        $positive = 0.0;
+        foreach ( $m[1] as $w ) {
+            $n = (float) $w;
+            if ( $n > 0 ) {
+                $positive += $n;
+            }
+        }
+        $this->assertEqualsWithDelta(100.0, $positive, 0.0001);
     }
 }

--- a/lib/tests/Services/Quiz1/Qti12ImporterTest.php
+++ b/lib/tests/Services/Quiz1/Qti12ImporterTest.php
@@ -140,6 +140,51 @@ XML;
         $this->assertSame(QuestionTypes::MULTIPLE_CHOICE, $quiz->questions[0]->type);
     }
 
+    public function testZeroScoreSetvarIsNotCorrect() {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop>
+  <assessment ident="a1" title="Zero">
+    <section ident="s1">
+      <item ident="i1" title="Pick">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>cc_profile</fieldlabel>
+              <fieldentry>cc.multiple_choice.v0p1</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material><mattext>Choose</mattext></material>
+          <response_lid ident="response" rcardinality="Single">
+            <render_choice>
+              <response_label ident="A"><material><mattext>Yes</mattext></material></response_label>
+              <response_label ident="B"><material><mattext>No</mattext></material></response_label>
+            </render_choice>
+          </response_lid>
+        </presentation>
+        <resprocessing>
+          <respcondition>
+            <conditionvar><varequal respident="response">B</varequal></conditionvar>
+            <setvar action="Set" varname="SCORE">0</setvar>
+          </respcondition>
+          <respcondition>
+            <conditionvar><varequal respident="response">A</varequal></conditionvar>
+            <setvar action="Set" varname="SCORE">100</setvar>
+          </respcondition>
+        </resprocessing>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>
+XML;
+        list($quiz, $warnings) = Qti12Importer::import($xml);
+        $this->assertSame(array(), $warnings);
+        $this->assertTrue($quiz->questions[0]->answers[0]->correct);
+        $this->assertFalse($quiz->questions[0]->answers[1]->correct);
+    }
+
     public function testEmptyXmlThrows() {
         $this->expectException(ImportException::class);
         Qti12Importer::import('<questestinterop></questestinterop>');

--- a/lib/tests/Services/Quiz1/Qti12ImporterTest.php
+++ b/lib/tests/Services/Quiz1/Qti12ImporterTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use Tsugi\Services\Quiz1\ImportException;
+use Tsugi\Services\Quiz1\Qti12Exporter;
+use Tsugi\Services\Quiz1\Qti12Importer;
+use Tsugi\Services\Quiz1\QuestionTypes;
+use Tsugi\Services\Quiz1\SampleQuiz;
+
+class Qti12ImporterTest extends \PHPUnit\Framework\TestCase
+{
+    public function testGoldenSampleRoundTrip() {
+        $xml = file_get_contents(__DIR__ . '/../../fixtures/Quiz1/sample-qti.xml');
+        list($quiz, $warnings) = Qti12Importer::import($xml);
+        $this->assertSame(array(), $warnings);
+        $this->assertSame('QTI Export Test', $quiz->title);
+        $this->assertStringContainsString('Sample quiz', $quiz->instructions);
+        $this->assertCount(6, $quiz->questions);
+
+        $types = array();
+        foreach ( $quiz->orderedQuestions() as $q ) {
+            $types[] = $q->type;
+        }
+        $this->assertSame(
+            array(
+                QuestionTypes::MULTIPLE_CHOICE,
+                QuestionTypes::MULTIPLE_RESPONSE,
+                QuestionTypes::TRUE_FALSE,
+                QuestionTypes::ESSAY,
+                QuestionTypes::FILL_BLANK,
+                QuestionTypes::PATTERN_MATCH,
+            ),
+            $types
+        );
+
+        $mc = $quiz->questions[0];
+        $this->assertSame('HTTP protocol', $mc->title);
+        $this->assertSame(1, $mc->points);
+        $this->assertTrue($mc->answers[0]->correct);
+        $this->assertSame('HTTP', strip_tags($mc->answers[0]->text));
+        $this->assertFalse($mc->answers[1]->correct);
+
+        $mr = $quiz->questions[1];
+        $this->assertSame(2, $mr->points);
+        $correct = array();
+        foreach ( $mr->answers as $ans ) {
+            if ( $ans->correct ) {
+                $correct[] = strip_tags($ans->text);
+            }
+        }
+        $this->assertSame(array('GET', 'POST'), $correct);
+
+        $tf = $quiz->questions[2];
+        $this->assertSame('True', $tf->answers[0]->text);
+        $this->assertFalse($tf->answers[0]->correct);
+        $this->assertTrue($tf->answers[1]->correct);
+
+        $essay = $quiz->questions[3];
+        $this->assertSame(5, $essay->points);
+        $this->assertStringContainsString('Representational State Transfer', $essay->sample_solution);
+
+        $fib = $quiz->questions[4];
+        $this->assertSame(array('80', 'eighty'), array(
+            $fib->answers[0]->text,
+            $fib->answers[1]->text,
+        ));
+
+        $pm = $quiz->questions[5];
+        $this->assertSame('Script', $pm->answers[0]->text);
+        $this->assertFalse($pm->case_sensitive);
+    }
+
+    public function testExporterImporterRoundTrip() {
+        $xml = Qti12Exporter::export(SampleQuiz::build(1));
+        list($quiz, $warnings) = Qti12Importer::import($xml);
+        $this->assertSame(array(), $warnings);
+        $this->assertCount(6, $quiz->questions);
+        $this->assertSame(QuestionTypes::PATTERN_MATCH, $quiz->questions[5]->type);
+        $this->assertStringContainsString('<strong>all</strong>', $quiz->questions[1]->prompt);
+    }
+
+    public function testCanvasQuestionTypeMetadata() {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop>
+  <assessment ident="a1" title="Canvas">
+    <section ident="s1">
+      <item ident="i1" title="Pick">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_choice_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>3</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material><mattext>Choose</mattext></material>
+          <response_lid ident="response" rcardinality="Single">
+            <render_choice>
+              <response_label ident="A"><material><mattext>Yes</mattext></material></response_label>
+              <response_label ident="B"><material><mattext>No</mattext></material></response_label>
+            </render_choice>
+          </response_lid>
+        </presentation>
+        <resprocessing>
+          <respcondition>
+            <conditionvar><varequal respident="response">A</varequal></conditionvar>
+            <setvar action="Set" varname="SCORE">100</setvar>
+          </respcondition>
+        </resprocessing>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>
+XML;
+        list($quiz, $warnings) = Qti12Importer::import($xml);
+        $this->assertSame(array(), $warnings);
+        $this->assertSame(QuestionTypes::MULTIPLE_CHOICE, $quiz->questions[0]->type);
+        $this->assertSame(3, $quiz->questions[0]->points);
+        $this->assertTrue($quiz->questions[0]->answers[0]->correct);
+    }
+
+    public function testZipContainingQti() {
+        $xml = Qti12Exporter::export(SampleQuiz::buildMinimal(1));
+        $tmp = tempnam(sys_get_temp_dir(), 'q1z');
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($tmp, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+        $zip->addFromString('quiz/assessment.xml', $xml);
+        $zip->close();
+        $bytes = file_get_contents($tmp);
+        @unlink($tmp);
+
+        list($quiz, $warnings) = Qti12Importer::import($bytes);
+        $this->assertSame(array(), $warnings);
+        $this->assertCount(1, $quiz->questions);
+        $this->assertSame(QuestionTypes::MULTIPLE_CHOICE, $quiz->questions[0]->type);
+    }
+
+    public function testEmptyXmlThrows() {
+        $this->expectException(ImportException::class);
+        Qti12Importer::import('<questestinterop></questestinterop>');
+    }
+
+    public function testInvalidXmlThrows() {
+        $this->expectException(ImportException::class);
+        Qti12Importer::import('not xml at all');
+    }
+}

--- a/lib/tests/Services/Quiz1/Qti12ImporterTest.php
+++ b/lib/tests/Services/Quiz1/Qti12ImporterTest.php
@@ -140,6 +140,23 @@ XML;
         $this->assertSame(QuestionTypes::MULTIPLE_CHOICE, $quiz->questions[0]->type);
     }
 
+    public function testZipWithTooManyEntriesIsRejected() {
+        $tmp = tempnam(sys_get_temp_dir(), 'q1z');
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($tmp, ZipArchive::CREATE | ZipArchive::OVERWRITE));
+        $limit = Qti12Importer::MAX_ZIP_ENTRIES;
+        for ( $i = 0; $i <= $limit; $i++ ) {
+            $zip->addFromString('pad/file'.$i.'.txt', 'xxxxxxxxxxxxxxxxxxxx');
+        }
+        $zip->close();
+        $bytes = file_get_contents($tmp);
+        @unlink($tmp);
+
+        $this->expectException(ImportException::class);
+        $this->expectExceptionMessage('too many files');
+        Qti12Importer::import($bytes);
+    }
+
     public function testZeroScoreSetvarIsNotCorrect() {
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GIFT quiz export and import.
  * Added QTI 1.2 and IMSCC quiz import.
  * Quiz pages now provide import and export actions for supported formats.
  * Imported questions can be appended to existing quizzes, with warnings for unsupported content.
  * Partial imports can succeed when individual questions cannot be processed.
* **Bug Fixes**
  * Improved multiple-response scoring and true/false feedback in GIFT exports.
  * Added safeguards for oversized or invalid QTI archives.
* **Documentation**
  * Updated quiz documentation with supported formats, workflows, routes, and interchange details.
* **Tests**
  * Added coverage for GIFT round trips and QTI import scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->